### PR TITLE
FieldDetector: fall back to default_object_type when Rule isn't a class label

### DIFF
--- a/src/detection_recorder.cpp
+++ b/src/detection_recorder.cpp
@@ -71,7 +71,7 @@ std::optional<Detection> classify(const OnvifEvent& ev,
     std::string type;
     if      (rule_it->second == "Human")   type = "human";
     else if (rule_it->second == "Vehicle") type = "vehicle";
-    else return {};
+    else type = fallback_type;  // Hikvision sends rule name in Rule field (e.g. "MyFieldDetector1"); the cam's AcuSense classifier already filtered to human/vehicle implicitly, so fall back to default_object_type and let NanoDet-M refine the class on the snapshot.
 
     return Detection{type, inside_it->second == "true", ev.event_time};
   }


### PR DESCRIPTION
Hikvision G2 cameras don't surface the AcuSense classifier output in the FieldDetector SOAP body — they put the rule name in `Source/Rule` instead. So `classify()` returns empty for every one of these events, but the topic still trips the ai_capable bookkeeping in `handle()`, which then filters out the camera's CellMotionDetector and MotionAlarm events. The camera ends up emitting nothing the recorder writes to `events`.

I ran into this on a UNVR G2 Pro with 8 adopted Hikvision DS-2CD2387G2-LSU/SL cameras on V5.7.19 (plus a 4MP DS-2CD2346G2-ISU/SL on V5.5.820 for testing) running Protect 7.1.60. Real SOAP body from `.148`:

```xml
<wsnt:NotificationMessage>
  <wsnt:Topic>tns1:RuleEngine/FieldDetector/ObjectsInside</wsnt:Topic>
  <wsnt:Message>
    <tt:Message UtcTime=\"...\" PropertyOperation=\"Changed\">
      <tt:Source>
        <tt:SimpleItem Name=\"VideoSourceConfigurationToken\" Value=\"VideoSourceToken\"/>
        <tt:SimpleItem Name=\"VideoAnalyticsConfigurationToken\" Value=\"VideoAnalyticsToken\"/>
        <tt:SimpleItem Name=\"Rule\" Value=\"MyFieldDetector1\"/>
      </tt:Source>
      <tt:Key><tt:SimpleItem Name=\"ObjectId\" Value=\"90920\"/></tt:Key>
      <tt:Data><tt:SimpleItem Name=\"IsInside\" Value=\"true\"/></tt:Data>
    </tt:Message>
  </wsnt:Message>
</wsnt:NotificationMessage>
```

`Rule` is the per-camera rule identifier (`MyFieldDetector1`, `MyFieldDetector2`, etc. — one per polygon you've drawn in the cam UI). The classifier output is implicit: the rule only fires if AcuSense decided the object matches the rule's configured target type (`detectionTarget=human` or `human,vehicle`), but that decision isn't carried in the message.

This patch flips the unknown-Rule branch from `return {}` to `type = fallback_type`, so the rest of the pipeline runs and NanoDet-M can refine the class on the snapshot. On the 8MP G2 turrets, NanoDet identifies persons reliably, and per-camera `--camera_object_types` overrides still apply afterwards. The `ai_capable_cameras_` behaviour is unchanged — once a camera fires a FieldDetector event, the recorder still prefers the AI events over basic motion for that camera.

### What I verified

- Pre-patch on production: FieldDetector op=Changed events arrived in the listener but produced no `events` rows. `.148`'s daily count after install: 0 `smartDetectZone` from FieldDetector despite the cam emitting them.
- Post-patch on the same production UNVR: walk past `.148`, journalctl shows
  ```
  topic=tns1:RuleEngine/FieldDetector/ObjectsInside op=Changed
  fetching snapshot from http://192.168.4.148/onvif-http/snapshot?Profile_1
  NanoDet-M detected class_id=0 (person)
  MSR stored snapshot as id=BC5E33B9AEB2-...
  ```
  and a `smartDetectZone` row appears in `events` with `smartDetectTypes=[\"person\"]` and the matching `thumbnailId`.

### Notes / caveats

- I don't know whether Hikvision puts the classifier output in a different SimpleItem on other firmware versions or G3/G4 lines. If they do, you could special-case it later; this patch keeps the existing `Human`/`Vehicle` matches and only changes the fall-through.
- Happy to follow up with a `HikvisionG2Emulator` testdata JSONL if you'd like a regression fixture — let me know what shape would fit best alongside the existing 108/109 emulators.
- The `ai_capable_cameras_` lock that was already in place is what makes this clean for noisy basic-motion cameras: once a FieldDetector event lands, MotionAlarm noise stops. That side of the design is great and I didn't touch it.

I've been running this on a 9-camera fleet for the last few hours; happy to share more telemetry if useful.