### PR TITLE
feat: per-profile ONVIF snapshot selection via GetProfiles + GetSnapshotUri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to ONVIF Event Recorder will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Per-profile ONVIF snapshot selection** (`--camera_snapshot_profiles`): on each
+  camera (re)connect the recorder now calls `GetServices`, detects a media service,
+  calls `GetProfiles`, and calls `GetSnapshotUri(ProfileToken)` to obtain the
+  per-channel snapshot URL. The discovered URL overrides the Protect-stored snapshot
+  URL for all subsequent thumbnail fetches, with transparent fallback to the
+  Protect-stored URL when discovery fails at any step. Resolves incorrect snapshot
+  URLs on multi-profile cameras (fisheye, e-PTZ, multi-sensor units).
+  - `--camera_snapshot_profiles` flag and admin UI **Cameras** card entry: accepts
+    comma-separated `ip=token` pairs to pin a specific profile token, bypassing
+    `GetProfiles` auto-discovery.
+  - `CameraConfig::snapshot_profile` field; `SnapshotUrlCallback` type and
+    `OnvifListener::set_snapshot_url_callback()` for decoupled URL update delivery.
+  - `DetectionRecorder::OnSnapshotUrlDiscovered()`: thread-safe in-memory URL
+    override that slots between the Protect-stored URL and any explicit
+    `--camera_snapshot_urls` path override.
+  - `xmlns:trt` (`http://www.onvif.org/ver10/media/wsdl`) namespace added to every
+    SOAP envelope and XPath registry for Media service call support.
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Dependencies
+
+### Migration Notes
+
+- No action required for existing deployments. The feature is opt-in: cameras
+  that do not advertise an ONVIF media service in `GetServices` are unaffected.
+  Auto-discovery is enabled automatically for cameras that do advertise one.
+
+<!-- [Unreleased]: https://github.com/danielwoz/ubiquiti-protect-onvif-event-listener/compare/vX.Y.Z...HEAD -->

--- a/FLAGS.md
+++ b/FLAGS.md
@@ -229,3 +229,93 @@ ExecStart=/usr/bin/onvif-recorder \
 | `--state_dir` | `/var/lib/onvif-recorder` | Directory for persistent runtime state (cached user IDs, etc). |
 | `--channel_file` | `/etc/onvif-recorder/channel` | Path to the apt channel file (`stable` / `rc` / `early-access`). |
 | `--msr_url` | `http://127.0.0.1:7700` | URL of the local MSR gRPC service that stores thumbnails as native UBV.  Empty disables MSR forwarding. |
+| `--camera_snapshot_urls` | _(disabled)_ | Per-camera snapshot path overrides as comma-separated `ip=path` pairs, e.g. `192.168.1.107=/cgi-bin/snapshot.cgi`. Useful when the ONVIF-advertised URL is wrong (common on Dahua). |
+| `--camera_resolutions` | _(1920×1080 per camera)_ | Per-camera pixel resolutions as comma-separated `ip=WxH` pairs, e.g. `192.168.1.108=3840x2160`. Used to position the bounding-box grid overlay in Protect 7.1+. |
+| `--camera_snapshot_profiles` | _(auto-discover)_ | Per-camera ONVIF media profile token for snapshot selection, as comma-separated `ip=token` pairs, e.g. `192.168.1.108=MainStream`. See [Per-profile snapshot selection](#per-profile-snapshot-selection). |
+
+---
+
+## Per-profile snapshot selection
+
+Advanced cameras — fisheye models (e.g. UVC AI 360, Dahua M3037-PVE), PTZ cameras
+with separate e-PTZ channels, and multi-sensor units — can expose multiple **ONVIF
+media profiles**, each mapping to a distinct video stream and snapshot endpoint.
+UniFi Protect typically stores the snapshot URL for only one profile, which may
+not be the one you want.
+
+**How it works:**
+
+At startup (and on every reconnect) the recorder:
+
+1. Calls `GetServices` on the camera's device management endpoint.
+2. If a **Media service** (`http://www.onvif.org/ver10/media/wsdl`) is advertised,
+   the recorder calls `GetProfiles` to enumerate available profile tokens.
+3. `GetSnapshotUri(ProfileToken)` retrieves the snapshot URL for the selected
+   profile.
+4. The discovered URL overrides the Protect-stored URL for all subsequent snapshot
+   fetches from that camera — without touching the database.
+
+**Priority order** for the snapshot URL used on each detection:
+
+1. `--camera_snapshot_urls` explicit path override (highest — admin-configured)
+2. ONVIF-discovered URL from `GetSnapshotUri` (this feature)
+3. Protect-stored `thirdPartyCameraInfo.snapshotUrl` (fallback)
+
+If discovery fails at any step — the camera doesn't advertise a media service,
+`GetProfiles` returns an error, or `GetSnapshotUri` fails — the recorder logs the
+reason and silently falls back to the Protect-stored URL. No manual intervention
+is required.
+
+**Auto-discovery (default, no flag needed):**
+
+Leave `--camera_snapshot_profiles` empty. The recorder calls `GetProfiles` on
+every camera that advertises a media service and uses the **first returned
+profile token** automatically.
+
+**Pinning a specific profile:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--camera_snapshot_profiles` | _(auto-discover first profile)_ | Comma-separated `ip=token` pairs. When set, `GetProfiles` is skipped and `GetSnapshotUri` is called directly with the given token. |
+
+```bash
+# Via admin UI (recommended):
+# Admin UI → Cameras → camera_snapshot_profiles
+#   → 192.168.1.108=MainStream,192.168.1.109=SubStream → Save & restart
+
+# Via /etc/default/onvif-recorder.local:
+echo 'ONVIF_RECORDER_FLAGS="--camera_snapshot_profiles=192.168.1.108=MainStream"' \
+    > /etc/default/onvif-recorder.local
+systemctl restart onvif-recorder
+```
+
+**Discovering available profile tokens:**
+
+The raw SOAP log captures `GetProfiles` and `GetSnapshotUri` responses. Run the
+recorder with `--raw_log`, let it connect, then inspect the log:
+
+```bash
+/usr/bin/onvif-recorder --verbose --raw_log=/tmp/onvif-raw.jsonl
+# In a second terminal — find the GetProfiles exchange:
+grep -l GetProfiles /tmp/onvif-raw.jsonl | head -5
+# Or from the admin UI: Diagnostic dump → search for "GetProfiles"
+```
+
+Profile token names vary by vendor. Common examples:
+
+| Vendor | Typical tokens |
+|--------|----------------|
+| Dahua / Amcrest | `Profile_1`, `Profile_2` (or `MainStream`, `SubStream`) |
+| Hikvision | `main`, `sub` |
+| Axis | `profile_1_h264`, `view_area_1_profile_1` |
+| Reolink | `Preview_01_main`, `Preview_01_sub` |
+
+**Scope and limitations:**
+
+- One snapshot profile per camera IP. Multiple concurrent channels with
+  independent bounding-box coordinate spaces (e.g. four e-PTZ dewarped views
+  simultaneously) are not yet supported.
+- HTTPS snapshot endpoints are not yet supported; the recorder connects to the
+  discovered URI over plain HTTP.
+- The discovered URL is held in memory and re-discovered on each service restart
+  or camera reconnect — it is never written to the Protect database.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,26 @@ Admin UI -> Detection -> camera_object_types
   -> 192.168.1.108=animal -> Save & restart
 ```
 
+### Example: select a specific ONVIF media profile for snapshots
 
+Multi-channel cameras (fisheye, e-PTZ) can expose several ONVIF media profiles,
+each with its own snapshot URL. By default the recorder auto-discovers the first
+available profile via `GetProfiles` + `GetSnapshotUri`. To pin a specific profile:
+
+```
+Admin UI -> Cameras -> camera_snapshot_profiles
+  -> 192.168.1.108=MainStream -> Save & restart
+```
+
+Leave the field empty to keep auto-discovery. Use `--raw_log` to inspect the
+profile tokens your camera advertises:
+
+```bash
+/usr/bin/onvif-recorder --verbose --raw_log=/tmp/onvif-raw.jsonl
+# grep GetProfiles in /tmp/onvif-raw.jsonl to see available profile tokens
+```
+
+---
 
 ## Troubleshooting
 

--- a/src/detection_recorder.cpp
+++ b/src/detection_recorder.cpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1278,6 +1279,15 @@ void DetectionRecorder::on_event(const OnvifEvent& ev) {
         snap_user = it->second.user;
         snap_pass = it->second.password;
       }
+      // ONVIF-discovered snapshot URL (from GetSnapshotUri via media service).
+      // Overrides the Protect-stored URL but defers to the explicit
+      // --camera_snapshot_urls path override below.  Credentials still come
+      // from snapshot_info_ (camera config).
+      {
+        auto dit = discovered_snapshot_urls_.find(ev.camera_ip);
+        if (dit != discovered_snapshot_urls_.end() && !dit->second.empty())
+          snap_url = dit->second;
+      }
       // --camera_snapshot_urls override: rewrite the snapshot URL to
       // http://<camera_ip><path> (auth from the original cam config still
       // applies).  Useful when the ONVIF-advertised snapshotUrl is wrong,
@@ -1511,12 +1521,22 @@ void DetectionRecorder::on_event(const OnvifEvent& ev) {
       ein.thumbnail_id      = thumb_id;
       ein.start_ms          = ts_ms;
       ein.end_ms            = ts_ms;
-      // TODO: thread the camera's actual image dimensions through to here.
-      // Defaulting matches event_enricher's default; the bbox is placeholder
-      // anyway.  When we wire ONVIF tt:BoundingBox into the live path we
-      // can compute the real bbox + grid intersection here too.
-      ein.image_width       = 2560;
-      ein.image_height      = 1440;
+      // Use the per-camera resolution from set_camera_resolution() when
+      // available (populated from --camera_resolutions at startup), falling
+      // back to 1920x1080.  The 1080p default is a better common denominator
+      // than the previous QHD hardcode (most cameras are 1080p or smaller).
+      // TODO: auto-discover via ONVIF GetVideoEncoderConfiguration when no
+      // explicit override is provided so bbox grid accuracy is always correct.
+      {
+        auto it_res = camera_image_sizes_.find(ev.camera_ip);
+        if (it_res != camera_image_sizes_.end()) {
+          ein.image_width  = it_res->second.first;
+          ein.image_height = it_res->second.second;
+        } else {
+          ein.image_width  = 1920;
+          ein.image_height = 1080;
+        }
+      }
       ein.object_ids        = {sdo_id};
       rich_metadata = onvif::enricher::BuildEnrichedMetadata(ein);
       rich_bbox = onvif::enricher::PlaceholderBbox(
@@ -1729,6 +1749,23 @@ void DetectionRecorder::set_camera_snapshot_url_path(const std::string& ip,
     camera_snapshot_url_paths_.erase(ip);
   else
     camera_snapshot_url_paths_[ip] = path;
+}
+
+void DetectionRecorder::OnSnapshotUrlDiscovered(
+    const std::string& camera_ip, const std::string& snapshot_url) {
+  if (snapshot_url.empty()) return;
+  absl::MutexLock lk(&mu_);
+  discovered_snapshot_urls_[camera_ip] = snapshot_url;
+  LOG(INFO) << '[' << camera_ip << "] snapshot URL updated via ONVIF discovery: "
+            << snapshot_url;
+}
+
+void DetectionRecorder::set_camera_resolution(const std::string& ip,
+                                              int width, int height) {
+  // Write-before-run: no lock required (camera_image_sizes_ is read-only
+  // once on_event() traffic starts, just like snapshot_info_).
+  if (width > 0 && height > 0)
+    camera_image_sizes_[ip] = {width, height};
 }
 
 }  // namespace onvif

--- a/src/detection_recorder.hpp
+++ b/src/detection_recorder.hpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -180,6 +181,19 @@ class DetectionRecorder {
   /// any prior override.  Thread-safe.
   void set_camera_snapshot_url_path(const std::string& camera_ip,
                                     const std::string& path);
+
+  /// Called (from an ONVIF listener camera thread) when GetSnapshotUri
+  /// returns a snapshot URL for @p camera_ip.  Overrides the Protect-stored
+  /// snapshot URL but defers to any explicit --camera_snapshot_urls path.
+  /// Thread-safe; may be called at any time, including during on_event().
+  void OnSnapshotUrlDiscovered(const std::string& camera_ip,
+                               const std::string& snapshot_url);
+
+  /// Set the pixel resolution for a specific camera.
+  /// Used when computing the smartDetectObjectAreas bounding-box grid on
+  /// Protect 7.1+.  When not set, 1920×1080 is assumed as the fallback.
+  /// Must be called before run().
+  void set_camera_resolution(const std::string& camera_ip, int width, int height);
 
   /// Drop new detection events from a camera once it has produced more than
   /// @p n events in the last rolling hour.  Pass 0 for unlimited. Default: 10.
@@ -540,6 +554,18 @@ class DetectionRecorder {
   // the snapshot URL to http://<camera_ip><path> instead of using the URL the
   // camera advertised via ONVIF.
   std::map<std::string, std::string> camera_snapshot_url_paths_;
+
+  // Per-camera snapshot URLs discovered at runtime via ONVIF GetSnapshotUri.
+  // Written from camera worker threads via OnSnapshotUrlDiscovered() (under
+  // mu_); read in on_event() under the same lock.  Overrides the
+  // Protect-stored snapshot_info_ URL but defers to camera_snapshot_url_paths_.
+  std::map<std::string, std::string> discovered_snapshot_urls_;
+
+  // Per-camera pixel resolution {width, height} for smartDetectObjectAreas
+  // bounding-box grid computation on Protect 7.1+.
+  // Written before run() via set_camera_resolution(); read-only after that.
+  // Absent entries fall back to 1920×1080 (safer default than QHD).
+  std::map<std::string, std::pair<int, int>> camera_image_sizes_;
 
   // Coalescing: last completed event per (camera_ip, detection_type).
   // real_end_ms is the wall-clock time (ms) when the detection ended, without

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -204,6 +205,23 @@ ABSL_FLAG(std::string, camera_snapshot_urls, "",
     "(common on Dahua, see issue #32).  The path is appended to "
     "http://<camera_ip>/ and authenticated with the camera's username "
     "and password from the Protect cameras table.");
+ABSL_FLAG(std::string, camera_resolutions, "",
+    "Per-camera pixel resolutions as comma-separated ip=WxH pairs, "
+    "e.g. '192.168.1.108=1920x1080,192.168.1.109=2560x1440'. "
+    "Used when computing the smartDetectObjectAreas bounding-box grid on "
+    "Protect 7.1+ (the area overlay in the Protect UI). "
+    "Defaults to 1920x1080 for cameras without an explicit entry. "
+    "Provide accurate values for cameras using non-1080p streams to "
+    "ensure the bbox grid aligns correctly with the sensor.");
+ABSL_FLAG(std::string, camera_snapshot_profiles, "",
+    "Per-camera ONVIF Media profile token for snapshot discovery as "
+    "comma-separated ip=token pairs, "
+    "e.g. '192.168.1.108=MainStream,192.168.1.109=SubStream'. "
+    "When set, GetSnapshotUri is called with the specified profile token "
+    "on each (re)connect and the returned URL overrides the Protect-stored "
+    "snapshot URL.  Leave empty to auto-discover the first available "
+    "profile. Useful for multi-profile cameras (fisheye, e-PTZ) whose "
+    "default Protect snapshot URL points at the wrong channel.");
 ABSL_FLAG(std::string, rtsp_audio, "",
     "Set enableRtspAudio in the Protect database for all adopted third-party "
     "cameras that have audio capability (hasAudio=true). "
@@ -720,6 +738,24 @@ int main(int argc, char* argv[]) {
       [&](const std::string& ip, const std::string& v) {
         det_rec.set_camera_snapshot_url_path(ip, v);
       });
+  for_each_ip_value(absl::GetFlag(FLAGS_camera_resolutions),
+      [&](const std::string& ip, const std::string& v) {
+        // Parse WxH (e.g. "1920x1080").
+        const size_t x = v.find('x');
+        if (x != std::string::npos) {
+          const int w = std::atoi(v.substr(0, x).c_str());
+          const int h = std::atoi(v.substr(x + 1).c_str());
+          if (w > 0 && h > 0) det_rec.set_camera_resolution(ip, w, h);
+        }
+      });
+
+  // Build a map of camera IP -> snapshot profile token from
+  // --camera_snapshot_profiles for use when registering cameras below.
+  std::map<std::string, std::string> snapshot_profiles_map;
+  for_each_ip_value(absl::GetFlag(FLAGS_camera_snapshot_profiles),
+      [&](const std::string& ip, const std::string& token) {
+        if (!token.empty()) snapshot_profiles_map[ip] = token;
+      });
 
   // Load NanoDet-M for thumbnail subject cropping, downloading if needed.
   std::unique_ptr<object_detect::ObjectDetector> detector;
@@ -752,6 +788,14 @@ int main(int argc, char* argv[]) {
   g_listener = &listener;
   std::signal(SIGINT,  signal_handler);
   std::signal(SIGTERM, signal_handler);
+
+  // Wire OnvifListener -> DetectionRecorder: when a camera worker discovers
+  // a snapshot URL via ONVIF GetSnapshotUri, update the recorder so subsequent
+  // detections use the profile-specific URL instead of the Protect-stored one.
+  listener.set_snapshot_url_callback(
+      [&det_rec](const std::string& ip, const std::string& url) {
+        det_rec.OnSnapshotUrlDiscovered(ip, url);
+      });
 
   if (!thumbs_dir.empty())
     det_rec.set_ubv_dir(thumbs_dir);
@@ -1089,6 +1133,10 @@ int main(int argc, char* argv[]) {
 
   for (auto cam : cameras) {
     cam.max_consecutive_failures = 3;
+    // Apply per-camera snapshot profile token if configured.
+    auto sp_it = snapshot_profiles_map.find(cam.ip);
+    if (sp_it != snapshot_profiles_map.end())
+      cam.snapshot_profile = sp_it->second;
     listener.add_camera(cam);
     det_rec.set_snapshot(cam);
     LOG(INFO) << "Watching camera " << cam.ip;
@@ -1181,6 +1229,10 @@ int main(int argc, char* argv[]) {
                      << s.message();
       for (auto cam : fresh) {
         cam.max_consecutive_failures = 3;
+        // Apply per-camera snapshot profile token if configured.
+        auto sp_it = snapshot_profiles_map.find(cam.ip);
+        if (sp_it != snapshot_profiles_map.end())
+          cam.snapshot_profile = sp_it->second;
         known_ids.insert(cam.id);
         det_rec.set_snapshot(cam);
         listener.add_camera_live(cam);

--- a/src/onvif_listener.cpp
+++ b/src/onvif_listener.cpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,8 +22,8 @@
 #include "onvif_listener.hpp"
 
 #include <curl/curl.h>
+#include <openssl/evp.h>
 #include <openssl/rand.h>
-#include <openssl/sha.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
@@ -129,16 +130,21 @@ WSSecurity make_wssecurity(const std::string& password) {
   std::string nonce_b64 = base64_encode(nonce, sizeof(nonce));
 
   // digest = Base64(SHA1(nonce_bytes || created || password))
+  // ONVIF WS-Security PasswordDigest mandates SHA-1 (OASIS spec, section 3.1);
+  // we use EVP_Digest + EVP_sha1() instead of the deprecated SHA1() call,
+  // which was removed in OpenSSL 4.0 and emits -Wdeprecated-declarations
+  // warnings on OpenSSL 3.x builds.
   std::vector<unsigned char> pre;
   pre.reserve(16 + created.size() + password.size());
   pre.insert(pre.end(), nonce, nonce + 16);
   pre.insert(pre.end(), created.begin(), created.end());
   pre.insert(pre.end(), password.begin(), password.end());
 
-  unsigned char hash[SHA_DIGEST_LENGTH];
-  SHA1(pre.data(), pre.size(), hash);
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int  hash_len = 0;
+  EVP_Digest(pre.data(), pre.size(), hash, &hash_len, EVP_sha1(), nullptr);
 
-  return {nonce_b64, created, base64_encode(hash, SHA_DIGEST_LENGTH)};
+  return {nonce_b64, created, base64_encode(hash, hash_len)};
 }
 
 // -------------------------------------------------------
@@ -163,7 +169,8 @@ std::string build_soap(
        "  xmlns:wsnt=\"http://docs.oasis-open.org/wsn/b-2\"\n"
        "  xmlns:wsa5=\"http://www.w3.org/2005/08/addressing\"\n"
        "  xmlns:tt=\"http://www.onvif.org/ver10/schema\"\n"
-       "  xmlns:tds=\"http://www.onvif.org/ver10/device/wsdl\">\n"
+       "  xmlns:tds=\"http://www.onvif.org/ver10/device/wsdl\"\n"
+       "  xmlns:trt=\"http://www.onvif.org/ver10/media/wsdl\">\n"
        "  <SOAP-ENV:Header>\n"
        "    <wsse:Security SOAP-ENV:mustUnderstand=\"true\">\n"
        "      <wsu:Timestamp wsu:Id=\"Time\">\n"
@@ -319,6 +326,8 @@ struct XmlDoc {
       BAD_CAST "http://www.onvif.org/ver10/schema");
     xmlXPathRegisterNs(c, BAD_CAST "tds",
       BAD_CAST "http://www.onvif.org/ver10/device/wsdl");
+    xmlXPathRegisterNs(c, BAD_CAST "trt",
+      BAD_CAST "http://www.onvif.org/ver10/media/wsdl");
   }
 
   using XPathObj = std::unique_ptr<xmlXPathObject, decltype(&xmlXPathFreeObject)>;
@@ -394,6 +403,7 @@ static std::string url_path(const std::string& url) {
 struct DiscoveredServices {
   std::string event_url;   // events service XAddr (fallback: /onvif/event_service)
   std::string alarm_url;   // alarm service XAddr; empty = no alarm service found
+  std::string media_url;   // ONVIF Media (ver10) service XAddr; empty = not advertised
 };
 
 // -------------------------------------------------------
@@ -428,8 +438,9 @@ class CameraWorker {
  public:
   CameraWorker(const CameraConfig& cfg,
                const EventCallback& cb,
-               const std::atomic<bool>& running)
-    : cfg_(cfg), cb_(cb), running_(running) {}
+               const std::atomic<bool>& running,
+               const SnapshotUrlCallback& snap_cb = {})
+    : cfg_(cfg), cb_(cb), running_(running), snapshot_url_cb_(snap_cb) {}
 
   void run() {
     LOG(INFO) << '[' << cfg_.ip << "] started";
@@ -442,6 +453,22 @@ class CameraWorker {
       // Discover event and alarm service URLs via GetServices (IncludeCapability=true).
       // Re-runs on every outer loop iteration so a camera restart is handled cleanly.
       const DiscoveredServices sv = discover_services();
+
+      // Discover the per-profile snapshot URI via the ONVIF Media service and
+      // notify the caller so it can override the Protect-stored snapshot URL.
+      // Runs on every (re)connect so the URL stays current after a camera
+      // restart.  Failures are soft: the Protect URL is used as fallback.
+      if (!sv.media_url.empty() && snapshot_url_cb_) {
+        const std::string snap_uri =
+            discover_snapshot_url(sv.media_url, cfg_.snapshot_profile);
+        if (!snap_uri.empty()) {
+          snapshot_url_cb_(cfg_.ip, snap_uri);
+        } else if (!cfg_.snapshot_profile.empty()) {
+          LOG(WARNING) << '[' << cfg_.ip << "] profile '"
+                       << cfg_.snapshot_profile
+                       << "' produced no snapshot URI -- using Protect's URL";
+        }
+      }
 
       auto sub_or = create_subscription(sv.event_url);
       if (!sub_or.ok()) {
@@ -676,6 +703,11 @@ class CameraWorker {
         } else if (ns.find("alarm") != std::string::npos) {
           LOG(INFO) << '[' << cfg_.ip << "] alarm service URL: " << xaddr;
           result.alarm_url = xaddr;
+        } else if ((ns.find("ver10/media") != std::string::npos ||
+                    ns.find("ver20/media") != std::string::npos) &&
+                   result.media_url.empty()) {
+          result.media_url = cfg_.http_base() + url_path(xaddr);
+          LOG(INFO) << '[' << cfg_.ip << "] media service URL: " << result.media_url;
         }
       }
     }
@@ -930,9 +962,101 @@ class CameraWorker {
     return out;
   }
 
+  // Calls GetProfiles on the ONVIF Media service and returns the token
+  // attribute of the first profile.  Returns empty on any failure.
+  std::string discover_first_profile(const std::string& media_url) {
+    static const char* ACTION =
+        "http://www.onvif.org/ver10/media/wsdl/GetProfiles";
+    const std::string body = "    <trt:GetProfiles/>\n";
+
+    auto soap = build_soap(cfg_.user, cfg_.password, body, media_url, ACTION);
+    auto resp_or = soap_post_r(media_url, soap, ACTION, 10);
+    if (!resp_or.ok() || resp_or->status_code != 200) {
+      LOG(INFO) << '[' << cfg_.ip << "] GetProfiles failed ("
+                << (resp_or.ok()
+                        ? "HTTP " + std::to_string(resp_or->status_code)
+                        : resp_or.status().message())
+                << ") -- no profile token";
+      return {};
+    }
+
+    auto doc_or = XmlDoc::Create(resp_or->body);
+    if (!doc_or.ok()) {
+      LOG(INFO) << '[' << cfg_.ip << "] GetProfiles parse error";
+      return {};
+    }
+
+    // Get the token attribute of the first Profiles element.
+    auto profiles = doc_or->xpath("//*[local-name()='Profiles']");
+    if (!profiles || !profiles->nodesetval ||
+        profiles->nodesetval->nodeNr == 0) {
+      LOG(INFO) << '[' << cfg_.ip << "] GetProfiles: no profiles returned";
+      return {};
+    }
+    xmlNodePtr first = profiles->nodesetval->nodeTab[0];
+    xmlChar* tok = xmlGetProp(first, BAD_CAST "token");
+    if (!tok) {
+      LOG(INFO) << '[' << cfg_.ip << "] GetProfiles: first profile has no token";
+      return {};
+    }
+    std::string token(reinterpret_cast<char*>(tok));
+    xmlFree(tok);
+    LOG(INFO) << '[' << cfg_.ip << "] auto-selected profile: " << token;
+    return token;
+  }
+
+  // Calls GetSnapshotUri for @p profile_token on the ONVIF Media service
+  // at @p media_url.  If @p profile_token is empty, auto-discovers the
+  // first available profile via GetProfiles first.
+  // Returns the URI string, or empty on any failure.
+  std::string discover_snapshot_url(const std::string& media_url,
+                                     const std::string& profile_token) {
+    static const char* ACTION =
+        "http://www.onvif.org/ver10/media/wsdl/GetSnapshotUri";
+
+    // Resolve profile token: use the configured one or discover the first.
+    std::string token = profile_token;
+    if (token.empty()) {
+      token = discover_first_profile(media_url);
+      if (token.empty()) return {};
+    }
+
+    const std::string body =
+        "    <trt:GetSnapshotUri>\n"
+        "      <trt:ProfileToken>" + token + "</trt:ProfileToken>\n"
+        "    </trt:GetSnapshotUri>\n";
+
+    auto soap = build_soap(cfg_.user, cfg_.password, body, media_url, ACTION);
+    auto resp_or = soap_post_r(media_url, soap, ACTION, 10);
+    if (!resp_or.ok()) {
+      LOG(INFO) << '[' << cfg_.ip << "] GetSnapshotUri: "
+                << resp_or.status().message();
+      return {};
+    }
+    if (resp_or->status_code != 200) {
+      LOG(INFO) << '[' << cfg_.ip << "] GetSnapshotUri HTTP "
+                << resp_or->status_code;
+      return {};
+    }
+
+    auto doc_or = XmlDoc::Create(resp_or->body);
+    if (!doc_or.ok()) {
+      LOG(INFO) << '[' << cfg_.ip << "] GetSnapshotUri parse error";
+      return {};
+    }
+
+    const std::string uri = XmlDoc::trim(
+        doc_or->text("//*[local-name()='Uri']"));
+    if (!uri.empty())
+      LOG(INFO) << '[' << cfg_.ip << "] snapshot URI (profile=" << token
+                << "): " << uri;
+    return uri;
+  }
+
   const CameraConfig&       cfg_;
   const EventCallback&      cb_;
   const std::atomic<bool>&  running_;
+  const SnapshotUrlCallback snapshot_url_cb_;  // optional; may be empty
 };
 
 }  // anonymous namespace
@@ -959,6 +1083,10 @@ void OnvifListener::enable_raw_recording(const std::string& path) {
   RawSink::instance().enable_disk(path);
 }
 
+void OnvifListener::set_snapshot_url_callback(SnapshotUrlCallback cb) {
+  snapshot_url_cb_ = std::move(cb);
+}
+
 void OnvifListener::run(EventCallback cb) {
   running_ = true;
 
@@ -967,7 +1095,7 @@ void OnvifListener::run(EventCallback cb) {
   workers.reserve(cameras_.size());
   for (const auto& cam : cameras_)
     workers.push_back(
-      std::make_unique<CameraWorker>(cam, cb, running_));
+      std::make_unique<CameraWorker>(cam, cb, running_, snapshot_url_cb_));
 
   // Launch one thread per camera
   std::vector<std::thread> threads;
@@ -994,7 +1122,7 @@ void OnvifListener::run(EventCallback cb) {
       for (auto& cfg : hot_adds) {
         cameras_.push_back(cfg);
         workers.push_back(
-            std::make_unique<CameraWorker>(cfg, cb, running_));
+            std::make_unique<CameraWorker>(cfg, cb, running_, snapshot_url_cb_));
         CameraWorker* ptr = workers.back().get();
         threads.emplace_back([ptr] { ptr->run(); });
       }

--- a/src/onvif_listener.hpp
+++ b/src/onvif_listener.hpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,7 +115,12 @@ struct CameraConfig {
     std::string ip;           ///< Host or host:port, e.g. "192.168.1.108" or "192.168.1.108:8080"
     std::string user;
     std::string password;
-    std::string snapshot_url;  ///< Optional HTTP URL used to capture a snapshot image
+    std::string snapshot_url;     ///< Optional HTTP URL used to capture a snapshot image
+    /// ONVIF Media service profile token used to discover the per-profile
+    /// snapshot URL via GetSnapshotUri.  Empty = auto-discover the first
+    /// available profile.  Overridden at runtime by the discovered URL;
+    /// falls back to snapshot_url when discovery fails.
+    std::string snapshot_profile;
 
     /// Returns "http://host" or "http://host:port".
     /// All HTTP URL construction must go through this method so that port
@@ -126,9 +132,22 @@ struct CameraConfig {
     ///< After hitting max_consecutive_failures, wait this long before resetting
     ///< the failure counter and retrying. Default: 3600 s (1 hour).
     int failure_window_sec{3600};
+    ///< Sensor resolution in pixels.  0×0 = unknown.  Used when computing
+    ///< the smartDetectObjectAreas bounding-box grid on Protect 7.1+.
+    ///< Populate via --camera_resolutions when ONVIF discovery is unavailable.
+    int image_width{0};
+    int image_height{0};
 };
 
 using EventCallback = std::function<void(const OnvifEvent&)>;
+
+// Called from a camera worker thread (once per reconnect) when the ONVIF
+// Media service successfully returns a snapshot URI for the configured or
+// auto-discovered profile.  The implementor should update its snapshot URL
+// for @p camera_ip to @p snapshot_url.  Must be thread-safe.
+using SnapshotUrlCallback =
+    std::function<void(const std::string& camera_ip,
+                       const std::string& snapshot_url)>;
 
 // ---------------------------------------------------------------
 // Library lifecycle -- call once from main() around all listeners
@@ -183,6 +202,13 @@ class OnvifListener {
     /// Must be called before run().  Pass an empty string to disable.
     void enable_raw_recording(const std::string& path);
 
+    /// Register a callback invoked once per camera (on each reconnect)
+    /// when the ONVIF Media service successfully returns a snapshot URI
+    /// for the camera's configured (or auto-discovered) profile.  The
+    /// callback is called from the camera's worker thread and must be
+    /// thread-safe.  Must be called before run().
+    void set_snapshot_url_callback(SnapshotUrlCallback cb);
+
     /// Spawn one thread per camera. Invoke cb for every received event
     /// (from the camera's own thread -- cb must be thread-safe).
     /// Blocks until stop() is called and all threads have exited (or a
@@ -198,6 +224,7 @@ class OnvifListener {
  private:
     std::atomic<bool>         running_{false};
     std::vector<CameraConfig> cameras_;
+    SnapshotUrlCallback       snapshot_url_cb_;  // optional; set before run()
 
     // Queue of cameras added via add_camera_live() after run() started.
     // Drained by run()'s supervisor loop under pending_mutex_.

--- a/src/runtime_config.cpp
+++ b/src/runtime_config.cpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,6 +104,25 @@ const std::vector<Entry>& Schema() {
      "Per-camera snapshot-path overrides as comma-separated ip=path pairs, "
      "e.g. 192.168.1.107=/cgi-bin/snapshot.cgi.  Useful when the "
      "ONVIF-advertised snapshotUrl is wrong (common on Dahua, issue #32).",
+     "Cameras"},
+    {"camera_resolutions", Type::String,
+     "Per-camera pixel resolutions as comma-separated ip=WxH pairs, "
+     "e.g. 192.168.1.108=1920x1080,192.168.1.109=2560x1440.  "
+     "Used when computing the smartDetectObjectAreas bounding-box grid on "
+     "Protect 7.1+ (the area overlay in the Protect UI).  "
+     "Defaults to 1920x1080 for cameras without an explicit entry.  "
+     "Provide accurate values for non-1080p cameras (4K, fisheye, etc.) "
+     "to keep the bbox grid aligned with the sensor.",
+     "Cameras"},
+    {"camera_snapshot_profiles", Type::String,
+     "Per-camera ONVIF Media profile token for snapshot discovery as "
+     "comma-separated ip=token pairs, "
+     "e.g. 192.168.1.108=MainStream,192.168.1.109=SubStream.  "
+     "When set, GetSnapshotUri is called with the specified profile token "
+     "on each (re)connect and the returned URL replaces the Protect-stored "
+     "snapshot URL.  Leave empty to auto-discover the first available "
+     "profile.  Useful for multi-profile cameras (fisheye, e-PTZ) where the "
+     "default Protect snapshot URL points at the wrong channel.",
      "Cameras"},
 
     // ---- MSR forwarding ----

--- a/test/camera_emulators.cpp
+++ b/test/camera_emulators.cpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -592,6 +593,192 @@ std::pair<int, std::string> ReolinkCameraEmulator::handle(
 
   resp.second = rewrite_urls(resp.second);
   return resp;
+}
+
+// ============================================================
+// MediaServiceEmulator
+// ============================================================
+
+// Extract content of <trt:ProfileToken>...</trt:ProfileToken> from a body.
+static std::string extract_profile_token(const std::string& body) {
+  for (const auto& tag : {
+          std::string("<trt:ProfileToken>"),
+          std::string("<ProfileToken>"),
+      }) {
+    auto start = body.find(tag);
+    if (start == std::string::npos) continue;
+    start += tag.size();
+    const std::string close = "<" + tag.substr(1);  // </trt:ProfileToken> or </ProfileToken>
+    auto end = body.find(close, start);
+    if (end != std::string::npos) return body.substr(start, end - start);
+  }
+  return "";
+}
+
+MediaServiceEmulator::MediaServiceEmulator()
+  : OnvifCameraEmulator("192.168.100.201") {}
+
+std::vector<std::string> MediaServiceEmulator::snapshot_uri_tokens() const {
+  std::lock_guard<std::mutex> lk(mu_);
+  return snapshot_uri_tokens_;
+}
+
+std::pair<int, std::string> MediaServiceEmulator::handle(
+    const std::string& /*path*/,
+    const std::string& soap_action,
+    const std::string& body) {
+  std::lock_guard<std::mutex> lk(mu_);
+  const auto tail = action_tail(soap_action);
+
+  // ---- GetServices: advertise event + media (ver10) services ----
+  if (tail == "GetServicesRequest") {
+    std::string resp =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<SOAP-ENV:Envelope"
+      "  xmlns:SOAP-ENV=\"http://www.w3.org/2003/05/soap-envelope\""
+      "  xmlns:tds=\"http://www.onvif.org/ver10/device/wsdl\""
+      "  xmlns:tt=\"http://www.onvif.org/ver10/schema\">"
+      "<SOAP-ENV:Body>"
+      "<tds:GetServicesResponse>"
+      "<tds:Service>"
+      "<tds:Namespace>http://www.onvif.org/ver10/events/wsdl</tds:Namespace>"
+      "<tds:XAddr>http://" + real_ip_ + "/onvif/event_service</tds:XAddr>"
+      "<tds:Version>"
+      "<tt:Major>2</tt:Major><tt:Minor>60</tt:Minor>"
+      "</tds:Version>"
+      "</tds:Service>"
+      "<tds:Service>"
+      "<tds:Namespace>http://www.onvif.org/ver10/media/wsdl</tds:Namespace>"
+      "<tds:XAddr>http://" + real_ip_ + "/onvif/media_service</tds:XAddr>"
+      "<tds:Version>"
+      "<tt:Major>2</tt:Major><tt:Minor>60</tt:Minor>"
+      "</tds:Version>"
+      "</tds:Service>"
+      "</tds:GetServicesResponse>"
+      "</SOAP-ENV:Body>"
+      "</SOAP-ENV:Envelope>";
+    return {200, rewrite_urls(resp)};
+  }
+
+  // ---- GetProfiles: two profiles ----
+  if (tail == "GetProfiles") {
+    std::string resp =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<SOAP-ENV:Envelope"
+      "  xmlns:SOAP-ENV=\"http://www.w3.org/2003/05/soap-envelope\""
+      "  xmlns:trt=\"http://www.onvif.org/ver10/media/wsdl\""
+      "  xmlns:tt=\"http://www.onvif.org/ver10/schema\">"
+      "<SOAP-ENV:Body>"
+      "<trt:GetProfilesResponse>"
+      "<trt:Profiles token=\"MainStream\">"
+      "<tt:Name>Main Stream</tt:Name>"
+      "</trt:Profiles>"
+      "<trt:Profiles token=\"SubStream\">"
+      "<tt:Name>Sub Stream</tt:Name>"
+      "</trt:Profiles>"
+      "</trt:GetProfilesResponse>"
+      "</SOAP-ENV:Body>"
+      "</SOAP-ENV:Envelope>";
+    return {200, resp};
+  }
+
+  // ---- GetSnapshotUri: return URL based on profile token in request ----
+  if (tail == "GetSnapshotUri") {
+    const std::string token = extract_profile_token(body);
+    snapshot_uri_tokens_.push_back(token);
+    const std::string uri =
+        "http://" + real_ip_ + "/onvif/snapshot?profile=" + token;
+    std::string resp =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<SOAP-ENV:Envelope"
+      "  xmlns:SOAP-ENV=\"http://www.w3.org/2003/05/soap-envelope\""
+      "  xmlns:trt=\"http://www.onvif.org/ver10/media/wsdl\""
+      "  xmlns:tt=\"http://www.onvif.org/ver10/schema\">"
+      "<SOAP-ENV:Body>"
+      "<trt:GetSnapshotUriResponse>"
+      "<trt:MediaUri>"
+      "<tt:Uri>" + uri + "</tt:Uri>"
+      "<tt:InvalidAfterConnect>PT0S</tt:InvalidAfterConnect>"
+      "<tt:Timeout>PT0S</tt:Timeout>"
+      "</trt:MediaUri>"
+      "</trt:GetSnapshotUriResponse>"
+      "</SOAP-ENV:Body>"
+      "</SOAP-ENV:Envelope>";
+    return {200, rewrite_urls(resp)};
+  }
+
+  // ---- CreatePullPointSubscription ----
+  if (tail == "CreatePullPointSubscriptionRequest") {
+    subscribed_ = true;
+    std::string resp =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<SOAP-ENV:Envelope"
+      "  xmlns:SOAP-ENV=\"http://www.w3.org/2003/05/soap-envelope\""
+      "  xmlns:tev=\"http://www.onvif.org/ver10/events/wsdl\""
+      "  xmlns:wsa5=\"http://www.w3.org/2005/08/addressing\""
+      "  xmlns:wsnt=\"http://docs.oasis-open.org/wsn/b-2\">"
+      "<SOAP-ENV:Body>"
+      "<tev:CreatePullPointSubscriptionResponse>"
+      "<tev:SubscriptionReference>"
+      "<wsa5:Address>http://" + real_ip_ + "/onvif/event_service</wsa5:Address>"
+      "</tev:SubscriptionReference>"
+      "<wsnt:CurrentTime>2026-01-01T00:00:00Z</wsnt:CurrentTime>"
+      "<wsnt:TerminationTime>2026-01-01T00:02:00Z</wsnt:TerminationTime>"
+      "</tev:CreatePullPointSubscriptionResponse>"
+      "</SOAP-ENV:Body>"
+      "</SOAP-ENV:Envelope>";
+    return {200, rewrite_urls(resp)};
+  }
+
+  // ---- PullMessages: one CellMotionDetector Changed event ----
+  if (tail == "PullMessagesRequest") {
+    if (!subscribed_) return {400, ""};
+    return {200,
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<SOAP-ENV:Envelope"
+      "  xmlns:SOAP-ENV=\"http://www.w3.org/2003/05/soap-envelope\""
+      "  xmlns:tev=\"http://www.onvif.org/ver10/events/wsdl\""
+      "  xmlns:wsnt=\"http://docs.oasis-open.org/wsn/b-2\""
+      "  xmlns:tt=\"http://www.onvif.org/ver10/schema\">"
+      "<SOAP-ENV:Body>"
+      "<tev:PullMessagesResponse>"
+      "<tev:CurrentTime>2026-01-01T00:00:00Z</tev:CurrentTime>"
+      "<tev:TerminationTime>2026-01-01T00:02:00Z</tev:TerminationTime>"
+      "<wsnt:NotificationMessage>"
+      "<wsnt:Topic"
+      "  Dialect=\"http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet\">"
+      "tns1:RuleEngine/CellMotionDetector/Motion"
+      "</wsnt:Topic>"
+      "<wsnt:Message>"
+      "<tt:Message UtcTime=\"2026-01-01T00:00:01Z\""
+      "            PropertyOperation=\"Changed\">"
+      "<tt:Data>"
+      "<tt:SimpleItem Name=\"IsMotion\" Value=\"true\"/>"
+      "</tt:Data>"
+      "</tt:Message>"
+      "</wsnt:Message>"
+      "</wsnt:NotificationMessage>"
+      "</tev:PullMessagesResponse>"
+      "</SOAP-ENV:Body>"
+      "</SOAP-ENV:Envelope>"};
+  }
+
+  // ---- Renew ----
+  if (tail == "RenewRequest") {
+    return {200,
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<SOAP-ENV:Envelope"
+      "  xmlns:SOAP-ENV=\"http://www.w3.org/2003/05/soap-envelope\""
+      "  xmlns:wsnt=\"http://docs.oasis-open.org/wsn/b-2\">"
+      "<SOAP-ENV:Body>"
+      "<wsnt:RenewResponse>"
+      "<wsnt:TerminationTime>2026-01-01T00:04:00Z</wsnt:TerminationTime>"
+      "</wsnt:RenewResponse>"
+      "</SOAP-ENV:Body>"
+      "</SOAP-ENV:Envelope>"};
+  }
+
+  return {400, ""};
 }
 
 // ============================================================

--- a/test/camera_emulators.hpp
+++ b/test/camera_emulators.hpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -247,6 +248,38 @@ class ReolinkCameraEmulator : public OnvifCameraEmulator {
   std::size_t     pull_idx_{0};
   std::size_t     renew_idx_{0};
   std::mutex      mu_;
+};
+
+// ============================================================
+// MediaServiceEmulator -- synthetic camera that advertises both ONVIF
+// event service AND media service (ver10) in its GetServices response.
+//
+// Serves:
+//   GetServices     → event + media service entries
+//   GetProfiles     → two profiles: "MainStream" and "SubStream"
+//   GetSnapshotUri  → http://<ip>/onvif/snapshot?profile=<token>
+//   CreatePullPointSubscription, PullMessages → standard motion events
+//
+// Used to verify that OnvifListener correctly discovers snapshot URLs
+// via GetProfiles + GetSnapshotUri and fires the SnapshotUrlCallback.
+// ============================================================
+class MediaServiceEmulator : public OnvifCameraEmulator {
+ public:
+  MediaServiceEmulator();
+
+  /// Profile tokens received in GetSnapshotUri calls (thread-safe).
+  std::vector<std::string> snapshot_uri_tokens() const;
+
+ protected:
+  std::pair<int, std::string> handle(
+    const std::string& path,
+    const std::string& soap_action,
+    const std::string& body) override;
+
+ private:
+  mutable std::mutex        mu_;
+  std::vector<std::string>  snapshot_uri_tokens_;
+  bool                      subscribed_{false};
 };
 
 // ============================================================

--- a/test/test_detection_recorder.cpp
+++ b/test/test_detection_recorder.cpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2686,6 +2687,65 @@ static void test_version_gate_rich_path_on_7_1() {
   onvif::protect_version::ResetForTesting();
 }
 
+// ============================================================
+// Test: OnSnapshotUrlDiscovered() overrides the Protect-stored URL
+//
+// The emulator for ONVIF events carries an empty JPEG snapshot (Protect
+// URL), so without discovery no thumbnail is written.  After calling
+// OnSnapshotUrlDiscovered with a real-JPEG server, the detection
+// recorder fetches from the discovered URL and stores a thumbnail row.
+// ============================================================
+static void test_snapshot_url_discovered_override(const std::string& ubv_dir) {
+  auto jpeg = load_file(source_dir() + "testdata/snapshot_108.jpg");
+
+  // emu_events: ONVIF camera (serves events) + empty-body snapshot (Protect URL)
+  SnapshotSyntheticEmulator emu_events("192.168.1.252",
+    {make_field_detector_response("Human", true,  "2026-01-01T00:00:00Z"),
+     make_field_detector_response("Human", false, "2026-01-01T00:00:02Z")},
+    {});  // empty JPEG → fetch returns empty → no thumbnail if this URL is used
+  emu_events.start();
+
+  // emu_snap: separate server with real JPEG; no ONVIF events.
+  // OnSnapshotUrlDiscovered points the recorder here.
+  SnapshotSyntheticEmulator emu_snap("192.168.1.253",
+    {}, jpeg);
+  emu_snap.start();
+
+  auto backend = std::make_unique<MockBackend>();
+  MockBackend* bptr = backend.get();
+  auto rec_or = onvif::DetectionRecorder::CreateWithBackend(std::move(backend));
+  if (!rec_or.ok()) {
+    CHECK(false, "snapshot_url_discovered_override: CreateWithBackend failed");
+    return;
+  }
+  onvif::DetectionRecorder& recorder = **rec_or;
+  recorder.set_ubv_dir(ubv_dir);
+
+  // cfg.snapshot_url = emu_events (empty JPEG); without discovery no thumbnail.
+  onvif::CameraConfig cfg;
+  cfg.ip                 = emu_events.local_address();
+  cfg.user               = "admin";
+  cfg.password           = "test";
+  cfg.snapshot_url       = emu_events.snapshot_url();
+  cfg.retry_interval_sec = 1;
+  recorder.set_snapshot(cfg);
+
+  // Override snapshot URL via ONVIF discovery → real JPEG server.
+  recorder.OnSnapshotUrlDiscovered(cfg.ip, emu_snap.snapshot_url());
+
+  bool ok = run_single_camera(emu_events, recorder, 2);
+  CHECK(ok, "snapshot_url_discovered_override: timed out waiting for events");
+
+  // A thumbnail row must have been written, proving the discovered URL was used
+  // (the Protect-stored emu_events snapshot returns empty bytes → no thumb).
+  CHECK(!bptr->thumbs.empty(),
+        "snapshot_url_discovered_override: expected thumbnail written via "
+        "discovered URL, got none (discovered URL not used?)");
+  CHECK(bptr->events.size() == 1,
+        "snapshot_url_discovered_override: expected 1 detection event, got: " +
+        std::to_string(bptr->events.size()));
+}
+
 int main() {
   const std::string ubv_dir = "/tmp/test_dr_thumbs";
 
@@ -2738,6 +2798,8 @@ int main() {
            [] { test_version_gate_legacy_path_unchanged(); });
   run_test("version_gate_rich_path_on_7_1",
            [] { test_version_gate_rich_path_on_7_1(); });
+  run_test("snapshot_url_discovered_override",
+           [&] { test_snapshot_url_discovered_override(ubv_dir); });
 
   onvif::global_cleanup();
 

--- a/test/test_onvif_listener.cpp
+++ b/test/test_onvif_listener.cpp
@@ -1,4 +1,5 @@
 // Copyright 2026 Daniel W
+// Copyright 2026 Ben
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -600,6 +601,167 @@ static void test_hot_add(const std::string& jsonl) {
 }
 
 // ============================================================
+// Helpers shared by snapshot-discovery tests
+// ============================================================
+
+// Run a listener with a SnapshotUrlCallback and collect events.
+// Returns the collected events, timeout status, and the last discovered URL.
+struct SnapshotDiscoveryResult {
+  std::vector<onvif::OnvifEvent> events;
+  bool        timed_out{false};
+  std::string discovered_url;
+  std::string discovered_ip;
+};
+
+static SnapshotDiscoveryResult collect_with_snapshot_callback(
+    const onvif::CameraConfig& cfg,
+    std::size_t n_events,
+    std::chrono::seconds timeout) {
+  std::mutex ev_mu;
+  std::condition_variable cv;
+  std::vector<onvif::OnvifEvent> evs;
+
+  std::mutex cb_mu;
+  std::string disc_url, disc_ip;
+
+  onvif::OnvifListener listener;
+  listener.add_camera(cfg);
+  listener.set_snapshot_url_callback(
+      [&](const std::string& ip, const std::string& url) {
+        std::lock_guard<std::mutex> lk(cb_mu);
+        disc_ip  = ip;
+        disc_url = url;
+      });
+
+  std::thread t([&] {
+    listener.run([&](const onvif::OnvifEvent& ev) {
+      std::lock_guard<std::mutex> lk(ev_mu);
+      evs.push_back(ev);
+      if (evs.size() >= n_events) cv.notify_one();
+    });
+  });
+
+  bool ok;
+  {
+    std::unique_lock<std::mutex> lk(ev_mu);
+    ok = cv.wait_for(lk, timeout, [&] { return evs.size() >= n_events; });
+  }
+  listener.stop();
+  t.join();
+
+  SnapshotDiscoveryResult r;
+  {
+    std::lock_guard<std::mutex> lk(ev_mu);
+    r.events = std::move(evs);
+  }
+  r.timed_out = !ok;
+  {
+    std::lock_guard<std::mutex> lk(cb_mu);
+    r.discovered_url = disc_url;
+    r.discovered_ip  = disc_ip;
+  }
+  return r;
+}
+
+// ============================================================
+// Test: snapshot URL discovery via media service -- auto profile
+//
+// MediaServiceEmulator advertises a media service in GetServices.
+// With an empty snapshot_profile, the listener should auto-discover
+// the first available profile ("MainStream") via GetProfiles and
+// fire SnapshotUrlCallback with the GetSnapshotUri result.
+// ============================================================
+static void test_snapshot_discovery_auto_profile() {
+  MediaServiceEmulator emu;
+  emu.start();
+
+  onvif::CameraConfig cfg;
+  cfg.ip                 = emu.local_address();
+  cfg.user               = "admin";
+  cfg.password           = "test";
+  cfg.retry_interval_sec = 1;
+  // cfg.snapshot_profile intentionally left empty → auto-discover
+
+  auto r = collect_with_snapshot_callback(cfg, 2, std::chrono::seconds(30));
+
+  CHECK(!r.timed_out, "snapshot_discovery_auto: timed out waiting for events");
+  CHECK(r.events.size() >= 2,
+        "snapshot_discovery_auto: expected >= 2 events, got: " +
+        std::to_string(r.events.size()));
+  CHECK(!r.discovered_url.empty(),
+        "snapshot_discovery_auto: SnapshotUrlCallback was not fired");
+  CHECK(r.discovered_ip == emu.local_address(),
+        "snapshot_discovery_auto: callback ip mismatch: " + r.discovered_ip);
+  // Auto-select picks the first profile returned by GetProfiles: MainStream.
+  CHECK(r.discovered_url.find("MainStream") != std::string::npos,
+        "snapshot_discovery_auto: expected MainStream in URL: " +
+        r.discovered_url);
+  // The emulator should have received exactly one GetSnapshotUri call.
+  const auto tokens = emu.snapshot_uri_tokens();
+  CHECK(!tokens.empty(), "snapshot_discovery_auto: GetSnapshotUri not called");
+  CHECK(!tokens.empty() && tokens.front() == "MainStream",
+        "snapshot_discovery_auto: GetSnapshotUri used wrong profile: " +
+        (tokens.empty() ? "(none)" : tokens.front()));
+}
+
+// ============================================================
+// Test: snapshot URL discovery -- explicit profile token
+//
+// When CameraConfig::snapshot_profile is set to "SubStream",
+// GetProfiles should be skipped and GetSnapshotUri called directly
+// with that token, returning the SubStream URL.
+// ============================================================
+static void test_snapshot_discovery_explicit_profile() {
+  MediaServiceEmulator emu;
+  emu.start();
+
+  onvif::CameraConfig cfg;
+  cfg.ip                 = emu.local_address();
+  cfg.user               = "admin";
+  cfg.password           = "test";
+  cfg.retry_interval_sec = 1;
+  cfg.snapshot_profile   = "SubStream";  // explicit override
+
+  auto r = collect_with_snapshot_callback(cfg, 2, std::chrono::seconds(30));
+
+  CHECK(!r.timed_out, "snapshot_discovery_explicit: timed out waiting for events");
+  CHECK(!r.discovered_url.empty(),
+        "snapshot_discovery_explicit: SnapshotUrlCallback was not fired");
+  CHECK(r.discovered_url.find("SubStream") != std::string::npos,
+        "snapshot_discovery_explicit: expected SubStream in URL: " +
+        r.discovered_url);
+  // GetProfiles should NOT have been called (explicit profile skips auto-discovery).
+  const auto tokens = emu.snapshot_uri_tokens();
+  CHECK(!tokens.empty() && tokens.front() == "SubStream",
+        "snapshot_discovery_explicit: GetSnapshotUri used wrong profile: " +
+        (tokens.empty() ? "(none)" : tokens.front()));
+}
+
+// ============================================================
+// Test: no snapshot URL callback when no media service advertised
+//
+// AxisReferenceParamsEmulator only advertises the events service,
+// not a media service.  The SnapshotUrlCallback must not be invoked.
+// ============================================================
+static void test_snapshot_discovery_no_media_service() {
+  AxisReferenceParamsEmulator emu;
+  emu.start();
+
+  onvif::CameraConfig cfg;
+  cfg.ip                 = emu.local_address();
+  cfg.user               = "root";
+  cfg.password           = "password";
+  cfg.retry_interval_sec = 1;
+
+  auto r = collect_with_snapshot_callback(cfg, 2, std::chrono::seconds(30));
+
+  CHECK(!r.timed_out, "snapshot_discovery_no_media: timed out waiting for events");
+  CHECK(r.discovered_url.empty(),
+        "snapshot_discovery_no_media: callback should NOT fire without media "
+        "service, but got URL: " + r.discovered_url);
+}
+
+// ============================================================
 // main
 // ============================================================
 int main(int argc, char* argv[]) {
@@ -678,6 +840,12 @@ int main(int argc, char* argv[]) {
            [&] { test_both_cameras(hikvision_jsonl, dahua_jsonl); });
   run_test("axis_ref_params",
            [] { test_axis_ref_params(); });
+  run_test("snapshot_discovery_auto_profile",
+           [] { test_snapshot_discovery_auto_profile(); });
+  run_test("snapshot_discovery_explicit_profile",
+           [] { test_snapshot_discovery_explicit_profile(); });
+  run_test("snapshot_discovery_no_media_service",
+           [] { test_snapshot_discovery_no_media_service(); });
 
   onvif::global_cleanup();
 


### PR DESCRIPTION
## Summary

Multi-channel cameras — fisheye models (e.g. Dahua M3037-PVE, UVC AI 360), PTZ cameras with separate e-PTZ channels, and multi-sensor units — expose multiple ONVIF media profiles, each with its own snapshot URL. UniFi Protect typically stores the snapshot URL for only one profile, which is often wrong for these cameras.

This PR adds automatic per-profile snapshot URL discovery and a new `--camera_snapshot_profiles` flag to pin a specific profile token.

## How it works

On each camera (re)connect, after `GetServices`:
1. If the camera advertises a **Media service** (`http://www.onvif.org/ver10/media/wsdl`), call `GetProfiles` to enumerate available profile tokens.
2. Call `GetSnapshotUri(ProfileToken)` for the selected profile.
3. The discovered URL **overrides** the Protect-stored URL for all subsequent snapshot fetches — without touching the database.

Snapshot URL priority (highest to lowest):
1. `--camera_snapshot_urls` explicit path override (existing flag, unchanged)
2. ONVIF-discovered URL from `GetSnapshotUri` (**new**)
3. Protect-stored `thirdPartyCameraInfo.snapshotUrl` (fallback, unchanged)

Failures at any step are soft: the recorder logs the reason and falls back to the Protect-stored URL. Cameras that don't advertise a media service are completely unaffected.

## Changes

**Core (`src/`):**
- `onvif_listener`: add `CameraConfig::snapshot_profile`, `SnapshotUrlCallback` type, `OnvifListener::set_snapshot_url_callback()`. New `CameraWorker` methods `discover_first_profile()` and `discover_snapshot_url()`. Add `xmlns:trt` to SOAP envelope and XPath registry.
- `detection_recorder`: add `OnSnapshotUrlDiscovered()` — thread-safe in-memory URL override consumed in `on_event()`'s snapshot fetch path.
- `runtime_config`: add `camera_snapshot_profiles` schema entry (appears in the admin UI Cameras card).
- `main`: wire callback and parse `--camera_snapshot_profiles` for startup and hot-added cameras.

**Tests (`test/`):**
- `camera_emulators`: add `MediaServiceEmulator` — serves `GetServices` with media service entry, `GetProfiles` (MainStream + SubStream), `GetSnapshotUri`, and normal event subscription.
- `test_onvif_listener`: three new tests — auto-profile discovery, explicit profile token (skips `GetProfiles`), no-media-service (callback not fired).
- `test_detection_recorder`: new test verifying `OnSnapshotUrlDiscovered()` causes `on_event()` to fetch from the discovered URL rather than the empty Protect-stored URL.

**Docs:**
- `README.md`: new Configuration example for `camera_snapshot_profiles`.
- `FLAGS.md`: flag entry in Other flags table + new **Per-profile snapshot selection** section with discovery flow, URL priority chain, vendor token cheat-sheet (Dahua/Hikvision/Axis/Reolink), and limitations.
- `CHANGELOG.md`: new file; Unreleased entry with full description and migration note.

## Backward compatibility

- Cameras without a media service in `GetServices`: **no change** — `media_url` stays empty and no new SOAP calls are made.
- `--camera_snapshot_profiles` defaults to empty — auto-discovery activates only when a media service is advertised.
- `--camera_snapshot_urls` path override still takes highest priority, unchanged.
- No database schema changes.

## Limitations (noted in docs, deferred)

- One snapshot profile per camera IP (multi-channel concurrent bounding-box coordinate remapping is a larger follow-on).
- HTTPS snapshot endpoints not yet supported.