### PR TITLE
Add push notification thumbnail support for ONVIF cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Admin UI -> Detection -> camera_object_types
   -> 192.168.1.108=animal -> Save & restart
 ```
 
+## Notification Thumbnails
+By default, object detection notifications will arrive with no thumbnail attached. In order to receive thumbnails as well, you'll need  to enable the global alarm manager.
+Details on how to do this and the associated limitations are in [`THUMBNAILS.md`](THUMBNAILS.md)
 
 
 ## Troubleshooting

--- a/THUMBNAILS.md
+++ b/THUMBNAILS.md
@@ -1,0 +1,82 @@
+# Push Notification Thumbnails
+
+This document explains how push notification thumbnails work for third-party
+(ONVIF) cameras on a UNVR running UniFi Protect 7.x, and what you must
+configure to enable them.
+
+---
+
+## Prerequisites
+
+### Enable Global Alarm Manager in Protect
+
+Protect has two alarm manager modes:
+
+| Mode | Description |
+|------|-------------|
+| **Local** (default) | Automations are managed by the Protect process in isolation. The push notification path cannot resolve thumbnails for third-party cameras. |
+| **Global** | Automations are managed by the UniFi OS (UOS) automation manager. The push notification pipeline has full access to camera models and event rows, enabling thumbnails. |
+
+**Steps to enable:**
+
+1. Open the UniFi Protect web UI.
+2. Go to **Settings -> Advanced -> Alarm Manager Mode**.
+3. Switch from **Local** to **Global**.
+4. Protect will migrate your existing automations to the global store automatically.
+
+> **Why this matters:** The `sendNotificationAction` inside Protect resolves
+> thumbnails by looking up the camera by its DB UUID, fetching the live event
+> row, and then reading the snapshot.  This lookup only works through the UOS
+> external automation manager endpoints, which require Global mode to be active.
+> Without it, the push fires but carries no thumbnail.
+
+> **Alternative (not recommended):** The equivalent manual DB change is:
+> ```sql
+> UPDATE nvrs
+>    SET "featureFlags" = replace(
+>          "featureFlags"::text,
+>          '"useExternalAlarmManager":false',
+>          '"useExternalAlarmManager":true')::json;
+> ```
+> Use this only as a recovery step if the UI migration fails — a Protect update
+> may overwrite it.
+
+---
+
+## Notification Format
+
+The notification title and body are formatted by Protect's own templates,
+not by onvif-recorder.  We do not send `title` or `body` fields in the
+payload; Protect determines them from the automation type and the resolved
+camera/event data.
+
+Confirmed output (from `service.log`, Protect 7.1.83):
+
+```
+Sending push with thumbnail for type "smart-detect":
+{
+  "title": "Smart Detection Recorded",
+  "body":  "UNVR's Gate has recorded a person."
+}
+```
+
+The camera name ("Gate") is correctly resolved via the DB UUID we pass in
+`sourceEvent.cameraId`.  The NVR name ("UNVR") comes from the NVR model.
+The object type ("a person") comes from the event key.
+
+---
+
+## Timeline Deep Link
+
+**Deep linking from a notificaiton to the event in the timeline is not working.**
+The push notification deep link is entirely constructed by Protect's sendNotificationAction — we have no control over it. For native camera detections, Protect includes routing data in the push payload's data object (something like {"eventId": "...", "cameraId": "..."}) that the mobile app parses to navigate directly to the clip.
+
+For the external alarm manager path we use, Protect logs only:
+
+"title": "Smart Detection Recorded",
+"body": "UNVR's Front Yard has recorded a person."
+The absence of navigation data in the FCM/APNs data object means the app receives the notification but has no event coordinate to route to, so it falls back to the "Find anything" search page. This is a limitation of how Protect's external alarm manager push action is implemented — it doesn't include the same eventId/cameraId routing fields that the native camera push path does.
+
+There is nothing in our payload we can change to fix this. We already pass eventId and sourceEvent.cameraId — Protect receives them, resolves the event, attaches the thumbnail, but still doesn't include routing data in the outbound push. That's a Protect-side gap in the external alarm manager implementation.
+
+The tap-to-clip behaviour is something only Ubiquiti can fix by updating sendNotificationAction for the external path to include eventId in the push data object — the same way it does for native cameras.

--- a/src/alarm_notifier.cpp
+++ b/src/alarm_notifier.cpp
@@ -171,47 +171,6 @@ static std::set<std::string> parse_sources(const std::string& arr) {
   return devs;
 }
 
-// Parse the camera list from GET /api/cameras.
-// Returns a map from uppercase-no-colon MAC → camera DB UUID.
-// The UUID is required by buildEventFromSource (Protect service.js) to resolve
-// the live event row and attach a thumbnail to push notifications.
-static std::map<std::string, std::string> parse_cameras(
-    const std::string& json) {
-  std::map<std::string, std::string> result;
-  bool in_str = false;
-  bool escape = false;
-  int depth = 0;
-  size_t start = std::string::npos;
-
-  for (size_t i = 0; i < json.size(); ++i) {
-    char c = json[i];
-    if (escape) { escape = false; continue; }
-    if (in_str) {
-      if (c == '\\') escape = true;
-      else if (c == '"') in_str = false;
-      continue;
-    }
-    if (c == '"') { in_str = true; continue; }
-    if (c == '{') {
-      if (depth == 0) start = i;
-      ++depth;
-    } else if (c == '}') {
-      --depth;
-      if (depth == 0 && start != std::string::npos) {
-        const std::string obj = json.substr(start, i - start + 1);
-        size_t p = find_key(obj, 0, "id");
-        std::string id;
-        if (p != std::string::npos) id = extract_string(obj, p);
-        p = find_key(obj, 0, "mac");
-        std::string mac;
-        if (p != std::string::npos) mac = extract_string(obj, p);
-        if (!id.empty() && !mac.empty()) result[mac] = id;
-        start = std::string::npos;
-      }
-    }
-  }
-  return result;
-}
 
 }  // namespace
 
@@ -642,18 +601,43 @@ void AlarmNotifier::refresh_alarms() {
 
   // ---- Step 1: build MAC → camera DB UUID map --------------------------------
   // Protect's buildEventFromSource looks up cameras by DB UUID (PK), not MAC.
-  // We need this map so notify() can pass sourceEvent.cameraId correctly and
-  // the push notification pipeline can attach thumbnails to outgoing pushes.
-  const std::string cams_json = http_get(url + "/api/cameras");
-  if (!cams_json.empty()) {
-    auto cam_map = parse_cameras(cams_json);
-    LOG(INFO) << "[alarm] loaded " << cam_map.size()
-              << " camera(s) from Protect API";
-    absl::MutexLock lk(&mu_);
-    mac_to_camera_id_ = std::move(cam_map);
+  // We query the DB directly rather than parsing the /api/cameras JSON response
+  // because Protect wraps the camera array in an envelope object whose exact
+  // schema varies by version, making JSON parsing fragile.  The DB is the
+  // single source of truth that Protect itself reads from.
+  if (!db_connstr_.empty()) {
+    PGconn* cam_conn = PQconnectdb(db_connstr_.c_str());
+    if (PQstatus(cam_conn) == CONNECTION_OK) {
+      PGresult* cam_res = onvif::pg::ExecParamsWithTimeout(
+          cam_conn, /*timeout_ms=*/-1,
+          "SELECT id, mac FROM cameras",
+          0, nullptr, nullptr, nullptr, nullptr, 0);
+      if (PQresultStatus(cam_res) == PGRES_TUPLES_OK) {
+        std::map<std::string, std::string> cam_map;
+        const int nrows = PQntuples(cam_res);
+        for (int r = 0; r < nrows; ++r) {
+          std::string id  = PQgetvalue(cam_res, r, 0);
+          std::string mac = PQgetvalue(cam_res, r, 1);
+          if (!id.empty() && !mac.empty()) cam_map[mac] = id;
+        }
+        LOG(INFO) << "[alarm] loaded " << cam_map.size()
+                  << " camera(s) from DB";
+        absl::MutexLock lk(&mu_);
+        mac_to_camera_id_ = std::move(cam_map);
+      } else {
+        LOG(ERROR) << "[alarm] camera DB query failed: "
+                   << PQresultErrorMessage(cam_res);
+      }
+      PQclear(cam_res);
+      PQfinish(cam_conn);
+    } else {
+      LOG(ERROR) << "[alarm] camera DB connect failed: "
+                 << PQerrorMessage(cam_conn);
+      PQfinish(cam_conn);
+    }
   } else {
-    LOG(WARNING) << "[alarm] could not fetch camera list from Protect API "
-                 << "-- push thumbnails may be missing until next refresh";
+    LOG(WARNING) << "[alarm] no db_connstr configured -- camera UUID map "
+                 << "unavailable; push notifications will fire without thumbnails";
   }
 
   // ---- Step 2: load automations ----------------------------------------------

--- a/src/alarm_notifier.cpp
+++ b/src/alarm_notifier.cpp
@@ -22,6 +22,7 @@
 #include <cinttypes>
 #include <cstdio>
 #include <fstream>
+#include <map>
 #include <set>
 #include <string>
 #include <utility>
@@ -168,6 +169,48 @@ static std::set<std::string> parse_sources(const std::string& arr) {
     pos = p;
   }
   return devs;
+}
+
+// Parse the camera list from GET /api/cameras.
+// Returns a map from uppercase-no-colon MAC → camera DB UUID.
+// The UUID is required by buildEventFromSource (Protect service.js) to resolve
+// the live event row and attach a thumbnail to push notifications.
+static std::map<std::string, std::string> parse_cameras(
+    const std::string& json) {
+  std::map<std::string, std::string> result;
+  bool in_str = false;
+  bool escape = false;
+  int depth = 0;
+  size_t start = std::string::npos;
+
+  for (size_t i = 0; i < json.size(); ++i) {
+    char c = json[i];
+    if (escape) { escape = false; continue; }
+    if (in_str) {
+      if (c == '\\') escape = true;
+      else if (c == '"') in_str = false;
+      continue;
+    }
+    if (c == '"') { in_str = true; continue; }
+    if (c == '{') {
+      if (depth == 0) start = i;
+      ++depth;
+    } else if (c == '}') {
+      --depth;
+      if (depth == 0 && start != std::string::npos) {
+        const std::string obj = json.substr(start, i - start + 1);
+        size_t p = find_key(obj, 0, "id");
+        std::string id;
+        if (p != std::string::npos) id = extract_string(obj, p);
+        p = find_key(obj, 0, "mac");
+        std::string mac;
+        if (p != std::string::npos) mac = extract_string(obj, p);
+        if (!id.empty() && !mac.empty()) result[mac] = id;
+        start = std::string::npos;
+      }
+    }
+  }
+  return result;
 }
 
 }  // namespace
@@ -369,18 +412,144 @@ std::string AlarmNotifier::http_get(const std::string& url) {
   return body;
 }
 
-void AlarmNotifier::http_post(const std::string& url, const std::string& body) {
+long AlarmNotifier::http_post(const std::string& url,  // NOLINT(runtime/int)
+                               const std::string& body) {
   long code = perform_post(url, user_id_provider_->current(), body);  // NOLINT(runtime/int)
   if (code == 401 && user_id_provider_->try_refresh()) {
     LOG(INFO) << "[alarm] retrying POST " << url << " after user_id refresh";
     code = perform_post(url, user_id_provider_->current(), body);  // NOLINT(runtime/int)
   }
-  if (code == 0) return;  // network error already logged
+  if (code == 0) return code;  // network error already logged
   if (code < 200 || code >= 300) {
     LOG(ERROR) << "[alarm] POST " << url << " HTTP " << code;
   } else {
     LOG(INFO) << "[alarm] POST " << url << " → " << code;
   }
+  return code;
+}
+
+// ============================================================
+// Automation registration
+// ============================================================
+
+void AlarmNotifier::register_automation(const AutomationEntry& entry) {
+  // Build the /change payload understood by the UOS automation manager:
+  //
+  // {"type":"created","data":[{
+  //   "id":           "<automation-uuid>",
+  //   "title":        "<name>",
+  //   "is_paused":    false,
+  //   "triggers_data":[[{"id":"person","is_matched_externally":true}], ...],
+  //   "actions_data": [[{"id":"notify"}]]
+  // }]}
+  //
+  // triggers_data is a 2-D array where the outer dimension is OR and the inner
+  // is AND.  We emit one inner singleton per trigger type (OR semantics).
+  using onvif::util::json_str;
+
+  std::string triggers;
+  for (const auto& t : entry.trigger_types) {
+    if (!triggers.empty()) triggers += ',';
+    triggers += "[{\"id\":";
+    triggers += json_str(t);
+    triggers += ",\"is_matched_externally\":true}]";
+  }
+
+  std::string payload;
+  payload.reserve(256);
+  payload += "{\"type\":\"created\",\"data\":[{";
+  payload += "\"id\":";           payload += json_str(entry.id);
+  payload += ",\"title\":";       payload += json_str(entry.name);
+  payload += ",\"is_paused\":false";
+  payload += ",\"triggers_data\":["; payload += triggers; payload += "]";
+  payload += ",\"actions_data\":[[{\"id\":\"notify\"}]]";
+  payload += "}]}";
+
+  std::string url;
+  {
+    absl::MutexLock lk(&mu_);
+    url = protect_url_;
+  }
+  long code = http_post(  // NOLINT(runtime/int)
+      url + "/internal/automationManager/external/change", payload);
+  if (code == 204 || (code >= 200 && code < 300)) {
+    LOG(INFO) << "[alarm] registered automation " << entry.id
+              << " (\"" << entry.name << "\") with UOS automation manager";
+  } else {
+    LOG(ERROR) << "[alarm] failed to register automation " << entry.id
+               << " HTTP " << code;
+  }
+}
+
+// ============================================================
+// Internal notify payload builder
+// ============================================================
+
+// static
+std::string AlarmNotifier::build_notify_payload(
+    const std::string& alarm_id,
+    const std::string& event_key,
+    const std::string& camera_db_id,
+    const std::string& event_id,
+    uint64_t           ts_ms,
+    const std::string& user_id) {
+  using onvif::util::json_str;
+  char ts_buf[24];
+  std::snprintf(ts_buf, sizeof(ts_buf), "%" PRIu64, ts_ms);
+
+  // Target schema (derived from Protect service.js / defaultUosActionDataSchema):
+  //
+  // {
+  //   "alarm_id": "<automation-uuid>",
+  //   "events": [{
+  //     "id":    "<event_key>",           // EventKeys enum value e.g. "person"
+  //     "scope": { "site_id": "protect" },
+  //     "metadata": {
+  //       "event": {
+  //         "key":       "<event_key>",
+  //         "device":    "<camera_db_id>", // camera DB UUID (not MAC)
+  //         "eventId":   "<uuid>",         // real events.id → thumbnail anchor
+  //         "timestamp": <ms>,
+  //         "sourceEvent": {               // ← causes buildEventFromSource to
+  //           "cameraId": "<camera_db_id>" //   find live event + thumbnail
+  //         }
+  //       },
+  //       "allEvents": [{ "key":..., "device":..., "eventId":...,
+  //                       "timestamp":... }]
+  //     }
+  //   }],
+  //   "data":      { "is_critical": false },
+  //   "receivers": [{ "user_id": "<ucore-uuid>", "push": true,
+  //                   "email": false, "voip": false }]
+  // }
+  //
+  // The sourceEvent.cameraId field is the key difference from the legacy
+  // /api/automations/<id>/run path (which hardcodes "expectedNoEventId").
+  // Protect's buildEventFromSource uses cameraId to look up the CameraDecalModel
+  // by PK, then findEvent to fetch the event row (with DB fallback), and finally
+  // getThumbnail to resolve the snapshot URL attached to the push payload.
+
+  std::string p;
+  p.reserve(720);
+  p += "{\"alarm_id\":";           p += json_str(alarm_id);
+  p += ",\"events\":[{\"id\":";    p += json_str(event_key);
+  p += ",\"scope\":{\"site_id\":\"protect\"}";
+  p += ",\"metadata\":{\"event\":{";
+  p +=   "\"key\":";               p += json_str(event_key);
+  p +=   ",\"device\":";           p += json_str(camera_db_id);
+  p +=   ",\"eventId\":";          p += json_str(event_id);
+  p +=   ",\"timestamp\":";        p += ts_buf;
+  p +=   ",\"sourceEvent\":{\"cameraId\":"; p += json_str(camera_db_id); p += "}";
+  p += "},\"allEvents\":[{";
+  p +=   "\"key\":";               p += json_str(event_key);
+  p +=   ",\"device\":";           p += json_str(camera_db_id);
+  p +=   ",\"eventId\":";          p += json_str(event_id);
+  p +=   ",\"timestamp\":";        p += ts_buf;
+  p += "}]}}]";
+  p += ",\"data\":{\"is_critical\":false}";
+  p += ",\"receivers\":[{\"user_id\":"; p += json_str(user_id);
+  p += ",\"push\":true,\"email\":false,\"voip\":false}]}";
+  return p;
 }
 
 // ============================================================
@@ -470,6 +639,24 @@ void AlarmNotifier::refresh_alarms() {
     absl::MutexLock lk(&mu_);
     url = protect_url_;
   }
+
+  // ---- Step 1: build MAC → camera DB UUID map --------------------------------
+  // Protect's buildEventFromSource looks up cameras by DB UUID (PK), not MAC.
+  // We need this map so notify() can pass sourceEvent.cameraId correctly and
+  // the push notification pipeline can attach thumbnails to outgoing pushes.
+  const std::string cams_json = http_get(url + "/api/cameras");
+  if (!cams_json.empty()) {
+    auto cam_map = parse_cameras(cams_json);
+    LOG(INFO) << "[alarm] loaded " << cam_map.size()
+              << " camera(s) from Protect API";
+    absl::MutexLock lk(&mu_);
+    mac_to_camera_id_ = std::move(cam_map);
+  } else {
+    LOG(WARNING) << "[alarm] could not fetch camera list from Protect API "
+                 << "-- push thumbnails may be missing until next refresh";
+  }
+
+  // ---- Step 2: load automations ----------------------------------------------
   const std::string response = http_get(url + "/api/automations");
   if (response.empty()) return;
 
@@ -489,6 +676,17 @@ void AlarmNotifier::refresh_alarms() {
               << " sources=" << a.source_devices.size()
               << " cooldown=" << a.cooldown_enabled
               << "/" << a.cooldown_ms << "ms";
+  }
+
+  // ---- Step 3: register each enabled automation with the UOS store ----------
+  // The in-memory UOS automation manager (automationManager) requires a
+  // /change "created" call before /actions/notify will succeed.  This
+  // registration is lost on every Protect restart; we redo it here.
+  // notify() will also re-register on-demand when it receives HTTP 500.
+  for (const auto& entry : parsed) {
+    if (entry.enabled) {
+      register_automation(entry);
+    }
   }
 
   absl::MutexLock lk(&mu_);
@@ -513,10 +711,22 @@ void AlarmNotifier::notify(const std::string& obj_type,
   if (need_refresh) refresh_alarms();
 
   std::vector<AutomationEntry> automations_copy;
+  std::string camera_db_id;
   {
     absl::MutexLock lk(&mu_);
     automations_copy = automations_;
     url = protect_url_;
+    // Resolve camera MAC → DB UUID for the thumbnail lookup.
+    auto cam_it = mac_to_camera_id_.find(camera_mac);
+    if (cam_it != mac_to_camera_id_.end()) {
+      camera_db_id = cam_it->second;
+    }
+  }
+
+  if (camera_db_id.empty()) {
+    LOG(WARNING) << "[alarm] no DB UUID found for camera MAC " << camera_mac
+                 << " -- thumbnails will be missing; will retry on next "
+                 << "refresh_alarms() (every 5 min) or Protect restart";
   }
 
   for (const auto& automation : automations_copy) {
@@ -545,8 +755,35 @@ void AlarmNotifier::notify(const std::string& obj_type,
     }
 
     LOG(INFO) << "[alarm] triggering automation " << automation.id
-              << " for " << obj_type << " on " << camera_mac;
-    http_post(url + "/api/automations/" + automation.id + "/run", "{}");
+              << " for " << obj_type << " on " << camera_mac
+              << " event_id=" << event_id;
+    {
+      // Use the camera's DB UUID as the device identifier so that
+      // buildEventFromSource resolves the live event + thumbnail.
+      // Falls back to the MAC if the UUID is not yet known (no thumbnail,
+      // but the notification still fires).
+      const std::string device_id =
+          camera_db_id.empty() ? camera_mac : camera_db_id;
+
+      const std::string notify_url =
+          url + "/internal/automationManager/external/actions/notify";
+      const std::string payload = build_notify_payload(
+          automation.id, obj_type, device_id, event_id, ts_ms,
+          user_id_provider_->current());
+
+      long code = http_post(notify_url, payload);  // NOLINT(runtime/int)
+
+      // HTTP 500 ("Alarm not found") means the in-memory UOS registration
+      // was evicted, typically because Protect restarted.  Re-register and
+      // retry once; the next refresh_alarms() will also re-register.
+      if (code == 500) {
+        LOG(WARNING) << "[alarm] automation " << automation.id
+                     << " not found in UOS store (HTTP 500); "
+                     << "re-registering and retrying";
+        register_automation(automation);
+        http_post(notify_url, payload);
+      }
+    }
 
     // Record in automationsHistory so Protect UI shows hits and history.
     record_history(automation, obj_type, camera_mac, event_id, ts_ms);

--- a/src/alarm_notifier.hpp
+++ b/src/alarm_notifier.hpp
@@ -36,6 +36,20 @@ namespace onvif {
  * Records automation history in the Protect DB so hits appear in the Protect UI
  * and respects the "ignore repeated" cooldown setting.
  *
+ * Thumbnail strategy
+ * ------------------
+ * Protect's push path resolves thumbnails via buildEventFromSource, which looks
+ * up the camera by its DB UUID (not MAC).  On startup refresh_alarms() fetches
+ * GET /api/cameras to build a MAC → DB-UUID map and registers each automation
+ * with the in-memory UOS store via
+ *   POST /internal/automationManager/external/change
+ * so that subsequent calls to
+ *   POST /internal/automationManager/external/actions/notify
+ * succeed and produce push notifications with thumbnails.
+ *
+ * The in-memory registration is lost when Protect restarts.  notify() detects
+ * HTTP 500 ("Alarm not found") and re-registers before retrying once.
+ *
  * Usage
  * -----
  *   ProtectUserIdProvider provider(user_id, cache_path);
@@ -58,6 +72,8 @@ class AlarmNotifier {
                 std::string db_connstr = "");
 
   /// Fetch the current automation list from Protect API and cache it.
+  /// Also fetches the camera list to populate the MAC → DB-UUID map and
+  /// registers each enabled automation with the UOS in-memory store.
   void refresh_alarms();
 
   /// Trigger matching Protect automations for a detection event.
@@ -90,15 +106,35 @@ class AlarmNotifier {
   std::string db_connstr_;
   absl::Mutex mu_;
   std::vector<AutomationEntry> automations_;  // protected by mu_
-  std::map<std::string, uint64_t> last_fired_;  // automation_id → ms, protected by mu_
+  std::map<std::string, uint64_t> last_fired_;   // automation_id → ms, protected by mu_
+  std::map<std::string, std::string> mac_to_camera_id_;  // MAC → camera DB UUID, protected by mu_
   std::chrono::steady_clock::time_point last_refresh_{};
 
   static std::vector<AutomationEntry> parse_automations(
       const std::string& json);
   static size_t write_cb(char* ptr, size_t size, size_t nmemb, void* userdata);
 
+  // Build the JSON payload for POST /internal/automationManager/external/actions/notify.
+  // alarm_id     -- automation UUID (the "alarm" in UOS terminology)
+  // event_key    -- EventKeys enum string: "person", "vehicle", "animal", etc.
+  // camera_db_id -- camera UUID from GET /api/cameras (not MAC); passed as
+  //                 sourceEvent.cameraId so buildEventFromSource can resolve
+  //                 the live event row and attach the thumbnail to the push
+  // event_id     -- UUID of the just-inserted events row (real thumbnail anchor)
+  // ts_ms        -- event start ms-since-epoch
+  // user_id      -- UCore user UUID for the receivers array (schema requirement)
+  static std::string build_notify_payload(const std::string& alarm_id,
+                                          const std::string& event_key,
+                                          const std::string& camera_db_id,
+                                          const std::string& event_id,
+                                          uint64_t           ts_ms,
+                                          const std::string& user_id);
+
   std::string http_get(const std::string& url);
-  void http_post(const std::string& url, const std::string& body);
+  // POST helper; returns the HTTP status code (0 on network error).
+  // Handles 401 → user_id refresh → retry automatically.
+  long http_post(const std::string& url,   // NOLINT(runtime/int)
+                 const std::string& body);
   // Inner request workers; return the HTTP status code.  perform_get
   // also writes the response body into `*body`.  Empty body and non-200
   // codes are surfaced to the caller, which decides whether to retry
@@ -107,6 +143,14 @@ class AlarmNotifier {
                    std::string* body);
   long perform_post(const std::string& url, const std::string& user_id,  // NOLINT(runtime/int)
                     const std::string& body);
+
+  // Register one automation with the in-memory UOS automation manager via
+  //   POST /internal/automationManager/external/change  (type "created")
+  // so that subsequent /actions/notify calls can find it.
+  // Must be called once per automation on startup and again whenever
+  // /actions/notify returns HTTP 500 (in-memory state lost after restart).
+  void register_automation(const AutomationEntry& entry);
+
   void record_history(const AutomationEntry& automation,
                       const std::string& obj_type,
                       const std::string& camera_mac,

--- a/test/test_alarm_notifier.cpp
+++ b/test/test_alarm_notifier.cpp
@@ -86,6 +86,16 @@ int main() {
     }
   }
 
+  // HTTP 500 should trigger re-registration, other codes should not.
+  {
+    check(AlarmNotifierTest::should_re_register(500),
+          "HTTP 500 triggers re-registration");
+    check(!AlarmNotifierTest::should_re_register(204),
+          "HTTP 204 does not re-register");
+    check(!AlarmNotifierTest::should_re_register(401),
+          "HTTP 401 does not re-register");
+  }
+
   // Deleted entries are dropped.
   {
     const std::string json = R"([


### PR DESCRIPTION
### Summary
Push notifications for ONVIF camera detections previously fired without a thumbnail. This PR fixes that by switching from the legacy automation run endpoint to the UOS external automation manager notification endpoint, and by passing the camera's DB UUID so Protect can resolve the live event row and attach a snapshot to the outbound push.

### Background
The previous code triggered notifications via:
`POST /api/automations//run {}`
Protect's handler for this endpoint hardcodes `eventId = "expectedNoEventId"` internally, which makes thumbnail  resolution impossible - `getThumbnail()` is never called because there is no real event to look up.

### What changes

**New notification path**

Notifications now go through the UOS external automation manager:
`POST /internal/automationManager/external/actions/notify`

with a payload that includes the real `eventId` (the UUID of the just-written `events` row) and `sourceEvent.cameraId` (the camera's DB UUID). This causes Protect's `buildEventFromSource` → `findEvent` → `getThumbnail` chain to run, and the push arrives with a thumbnail.

**Automation registration**

The UOS automation manager holds its state in memory only. A registration step is now performed at startup and on-demand when Protect restarts: `POST /internal/automationManager/external/change` (type "created")

This seeds the in-memory store so subsequent `/actions/notify` calls succeed. If a notification returns HTTP 500 ("Alarm not found"), the notifier re-registers and retries automatically without dropping the event.

**Camera MAC → DB UUID map**

`buildEventFromSource` looks up cameras by their DB UUID (primary key), not by MAC address. `refresh_alarms()` now queries `SELECT id, mac FROM cameras` directly from the Protect PostgreSQL DB at startup to build this map. The DB
is queried rather than `GET /api/cameras` because the API response envelope varies by Protect version, making JSON parsing fragile.

**`http_post` return value**

Changed from `void` to `long` so `notify()` can inspect the HTTP status code and branch on HTTP 500 for the re-registration retry.

### Prerequisite: Global Alarm Manager

This feature requires the Protect **Global Alarm Manager** to be enabled:

> **Protect Settings → Alarm Manager → switch from Local to Global**

Protect migrates existing automations automatically. Without this setting, `useExternalAlarmManager` is `false` in the NVR config and the UOS automation manager endpoints return errors.

This is documented in `THUMBNAILS.md` (added in this PR).

### Confirmed working (UNVR, UniFi OS 5.1.19, Protect 7.1.83)

- Push notification fires on detection
- Thumbnail attached to notification
- Camera name correctly resolved in notification body
- Detection event appears in Protect timeline and search
- Event plays correctly when tapped from timeline or search
- Automatic re-registration after Protect restart (HTTP 500 retry path)

### Known limitation

Tapping the push notification opens the Protect "Find anything" search page rather than navigating directly to the detection clip. This is a limitation of Protect's external alarm manager `sendNotificationAction` implementation - it
does not include `eventId`/`cameraId` routing fields in the outbound FCM/APNs `data` object for this path, unlike the native camera push path. The event itself is fully correct and accessible via the timeline and search. This would
require a Protect-side fix.

### Files changed

- `alarm_notifier.hpp` - new `mac_to_camera_id_` member, `register_automation()` declaration, `http_post` return type, updated `build_notify_payload` parameter name, updated class doc comment
- `alarm_notifier.cpp` - DB-based camera UUID map, `register_automation()` implementation, `build_notify_payload` adds `sourceEvent.cameraId`, `http_post` returns status code, `notify()` does camera UUID lookup and HTTP 500 retry,  `refresh_alarms()` fetches cameras and registers automations on startup
- `THUMBNAILS.md` - new doc covering the architecture, prerequisite setup, confirmed notification format