### PR TITLE
Add --drop_unclassified_motion

### DIFF
--- a/FLAGS.md
+++ b/FLAGS.md
@@ -53,6 +53,7 @@ regardless of what the camera reports.
 |------|---------|-------------|
 | `--default_object_type` | `person` | Object type written for generic motion events that carry no object class. Valid values: `person`, `vehicle`, `animal`, `package`. |
 | `--camera_object_types` | _(disabled)_ | Comma-separated `ip=type` overrides applied to all events from each named camera, e.g. `192.168.1.108=animal,192.168.1.109=package`. |
+| `--drop_unclassified_motion` | `false` | Drop generic motion events (CellMotionDetector / MotionAlarm) that carry no ONVIF object class and that NanoDet-M cannot classify, instead of recording them as `--default_object_type`. Real camera AI events (Person / Vehicle / Pet) and `--camera_object_types` overrides are unaffected. Cuts false-positive clutter from AI cameras (e.g. Reolink) that also emit noisy basic-motion events. |
 
 **Example — wildlife camera on `.108` and package camera on `.109`:**
 ```bash

--- a/src/detection_recorder.cpp
+++ b/src/detection_recorder.cpp
@@ -1389,6 +1389,11 @@ void DetectionRecorder::set_detect_override(bool override) {
   detect_override_ = override;
 }
 
+void DetectionRecorder::set_drop_unclassified_motion(bool drop) {
+  absl::MutexLock lk(&mu_);
+  drop_unclassified_motion_ = drop;
+}
+
 void DetectionRecorder::set_use_msr_thumbnail_ids(bool use_msr) {
   absl::MutexLock lk(&mu_);
   use_msr_thumb_ids_ = use_msr;
@@ -1513,6 +1518,7 @@ void DetectionRecorder::on_event(const OnvifEvent& ev) {
     uint64_t pre_ms;
     const object_detect::ObjectDetector* det_ptr;
     bool det_override;
+    bool drop_unclassified;
     AlarmNotifier* alarm_notif;
     MsrClient* msr;
     bool msr_drop_on_failure;
@@ -1605,6 +1611,7 @@ void DetectionRecorder::on_event(const OnvifEvent& ev) {
       pre_ms       = pre_buffer_ms_;
       det_ptr      = detector_;
       det_override = detect_override_;
+      drop_unclassified = drop_unclassified_motion_;
       alarm_notif  = alarm_notifier_;
       msr          = msr_client_;
       msr_drop_on_failure = msr_drop_on_failure_;
@@ -1719,6 +1726,31 @@ void DetectionRecorder::on_event(const OnvifEvent& ev) {
                 object_detect::detection_type(det_result->class_id);
             obj_type = inferred;
             sdt_json = smart_detect_types_json(inferred);
+          }
+          // Drop unclassified generic motion when --drop_unclassified_motion
+          // is set: a pixel-change motion event with no per-camera override
+          // and no NanoDet-M detection would otherwise be recorded as the
+          // default_object_type (person), which floods the timeline with
+          // false positives on AI cameras that already emit proper
+          // Person/Vehicle/Pet events.  Discard it instead.  Only new events
+          // are dropped; a coalescing merge into an existing real event is
+          // left untouched.
+          //
+          // Matched on topic rather than det->from_fallback: a
+          // LineDetector/Crossed event that arrives without ClassTypes is
+          // also from_fallback, but it is a real rule-engine detection the
+          // camera deliberately reported, not pixel noise, so it stays.
+          const bool generic_motion =
+              ev.topic == "tns1:RuleEngine/CellMotionDetector/Motion" ||
+              ev.topic == "tns1:RuleEngine/tt:CellMotionDetector"     ||
+              ev.topic == "tns1:VideoSource/MotionAlarm";
+          if (drop_unclassified && generic_motion && det->from_fallback &&
+              cam_override_type.empty() && !det_result &&
+              coalesced_event_id.empty()) {
+            LOG(INFO) << '[' << ev.camera_ip
+                      << "] dropping unclassified motion event "
+                         "(--drop_unclassified_motion, no NanoDet-M detection)";
+            return;
           }
           // Only crop when we have a basis: an ONVIF bbox, or a loaded
           // detector (which may yield a result or fall back to smart-crop).

--- a/src/detection_recorder.hpp
+++ b/src/detection_recorder.hpp
@@ -252,6 +252,13 @@ class DetectionRecorder {
   /// bounding box provided by the camera. Has no effect if no detector is set.
   void set_detect_override(bool override);
 
+  /// When true, generic motion events (CellMotionDetector / MotionAlarm) that
+  /// carry no ONVIF object class and that NanoDet-M cannot classify are
+  /// dropped instead of being recorded as the default_object_type.  Real AI
+  /// events (Person / Vehicle / Pet) and per-camera overrides are unaffected.
+  /// Default false (preserves prior behaviour: record as default_object_type).
+  void set_drop_unclassified_motion(bool drop);
+
   /// When enabled, thumbnail IDs use the MSR "{MAC}-{timestamp_ms}" format
   /// (length != 24) matching the native Protect convention, instead of the
   /// default 24-char hex format.  Both formats are always written to the DB
@@ -549,6 +556,10 @@ class DetectionRecorder {
 
   // When true the detector is preferred over ONVIF-provided bounding boxes.
   bool detect_override_{false};
+
+  // When true, drop generic-motion events that NanoDet-M cannot classify
+  // instead of recording them as default_object_type_.  Default false.
+  bool drop_unclassified_motion_{false};
 
   // When true, thumbnail IDs use the MSR "{MAC}-{ts_ms}" format (len != 24).
   bool use_msr_thumb_ids_{false};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,6 +127,13 @@ ABSL_FLAG(bool, detect, true,
 ABSL_FLAG(bool, detect_override, false,
     "Run NanoDet-M on every thumbnail regardless of whether the camera "
     "provides an ONVIF bounding box. Implies --detect.");
+ABSL_FLAG(bool, drop_unclassified_motion, false,
+    "Drop generic motion events (CellMotionDetector, VideoSource/MotionAlarm) "
+    "that carry no ONVIF object class and that NanoDet-M cannot classify, "
+    "instead of recording them as --default_object_type. Real camera AI "
+    "events (Person/Vehicle/Pet) and --camera_object_types overrides are "
+    "unaffected. Useful with Reolink/other AI cameras that also emit noisy "
+    "basic-motion events. Default false.");
 ABSL_FLAG(std::string, event_log, "",
     "Path for the parsed-event JSON Lines log file. "
     "Each line is one ONVIF event with topic, source, data, and timestamp. "
@@ -799,6 +806,8 @@ int main(int argc, char* argv[]) {
 
   // Object type configuration.
   det_rec.set_default_object_type(absl::GetFlag(FLAGS_default_object_type));
+  det_rec.set_drop_unclassified_motion(
+      absl::GetFlag(FLAGS_drop_unclassified_motion));
 
   // Helper to walk a comma-separated `ip=value` list and call a per-pair
   // callback.  Used by --camera_object_types / --camera_coalesce_window_sec

--- a/src/runtime_config.cpp
+++ b/src/runtime_config.cpp
@@ -67,6 +67,13 @@ const std::vector<Entry>& Schema() {
      "Default object type for events that arrive without a class "
      "(e.g. 'motion', 'person', 'vehicle').",
      "Detection"},
+    {"drop_unclassified_motion", Type::Bool,
+     "Drop generic motion events with no ONVIF class that NanoDet-M cannot "
+     "classify, instead of recording them as default_object_type.  Camera AI "
+     "events (Person/Vehicle/Pet) and per-camera overrides are unaffected.  "
+     "Cuts false-positive clutter from AI cameras (e.g. Reolink) that also "
+     "emit noisy basic-motion events.",
+     "Detection"},
     {"camera_object_types", Type::String,
      "Per-camera type overrides as comma-separated ip=type pairs, e.g. "
      "192.168.1.108=person,192.168.1.109=vehicle.",

--- a/test/test_detection_recorder.cpp
+++ b/test/test_detection_recorder.cpp
@@ -2924,6 +2924,102 @@ static void test_version_gate_rich_path_on_7_1() {
   onvif::protect_version::ResetForTesting();
 }
 
+// ============================================================
+// --drop_unclassified_motion test
+//
+// With the flag on and no detector loaded, generic motion (which NanoDet-M
+// cannot classify) is dropped rather than recorded as default_object_type;
+// a real camera AI event is still recorded.
+// ============================================================
+static void test_drop_unclassified_motion(const std::string& ubv_dir) {
+  // Part 1: generic motion is dropped.
+  {
+    auto backend = std::make_unique<MockBackend>();
+    MockBackend* bptr = backend.get();
+    auto rec_or =
+        onvif::DetectionRecorder::CreateWithBackend(std::move(backend));
+    CHECK(rec_or.ok(), "drop_unclassified: CreateWithBackend failed");
+    onvif::DetectionRecorder& recorder = **rec_or;
+    recorder.set_ubv_dir(ubv_dir);
+    recorder.set_drop_unclassified_motion(true);
+
+    auto jpeg = load_file(source_dir() + "testdata/snapshot_108.jpg");
+    SnapshotSyntheticEmulator emu("192.168.1.211",
+      {make_cell_motion_response(true,  "2026-03-24T10:00:00Z"),
+       make_cell_motion_response(false, "2026-03-24T10:00:05Z")},
+      jpeg);
+    emu.start();
+
+    bool ok = run_single_camera(emu, recorder, 2);
+    CHECK(ok, "drop_unclassified: timed out (motion)");
+    int events = static_cast<int>(bptr->events.size());
+    CHECK(events == 0,
+          "drop_unclassified: expected 0 events for unclassified motion, got "
+          + std::to_string(events));
+  }
+
+  // Part 2: a real AI event (human -> person) is still recorded.
+  {
+    auto backend = std::make_unique<MockBackend>();
+    MockBackend* bptr = backend.get();
+    auto rec_or =
+        onvif::DetectionRecorder::CreateWithBackend(std::move(backend));
+    CHECK(rec_or.ok(), "drop_unclassified: CreateWithBackend failed (ai)");
+    onvif::DetectionRecorder& recorder = **rec_or;
+    recorder.set_ubv_dir(ubv_dir);
+    recorder.set_drop_unclassified_motion(true);
+
+    auto jpeg = load_file(source_dir() + "testdata/snapshot_108.jpg");
+    SnapshotSyntheticEmulator emu("192.168.1.212",
+      {make_human_shape_response(true,  "2026-03-24T10:01:00Z"),
+       make_human_shape_response(false, "2026-03-24T10:01:05Z")},
+      jpeg);
+    emu.start();
+
+    bool ok = run_single_camera(emu, recorder, 2);
+    CHECK(ok, "drop_unclassified: timed out (ai)");
+    int events = static_cast<int>(bptr->events.size());
+    CHECK(events == 1,
+          "drop_unclassified: expected AI event recorded, got "
+          + std::to_string(events));
+    int person_sdo = 0;
+    for (auto& s : bptr->sdos) if (s.obj_type == "person") ++person_sdo;
+    CHECK(person_sdo == 1,
+          "drop_unclassified: expected 1 person SDO, got "
+          + std::to_string(person_sdo));
+  }
+
+  // Part 3: a line crossing with no ClassTypes is from_fallback too, but it
+  // is a real rule-engine detection, not pixel noise.  The flag must not
+  // swallow it.
+  {
+    auto backend = std::make_unique<MockBackend>();
+    MockBackend* bptr = backend.get();
+    auto rec_or =
+        onvif::DetectionRecorder::CreateWithBackend(std::move(backend));
+    CHECK(rec_or.ok(), "drop_unclassified: CreateWithBackend failed (cross)");
+    onvif::DetectionRecorder& recorder = **rec_or;
+    recorder.set_ubv_dir(ubv_dir);
+    recorder.set_drop_unclassified_motion(true);
+    recorder.set_buffer(0, 0);
+    recorder.set_momentary_event_sec(6);
+    recorder.set_coalesce_window(0);
+
+    onvif::OnvifEvent ev;
+    ev.camera_ip   = "192.168.1.213";
+    ev.topic       = "tns1:RuleEngine/LineDetector/Crossed";
+    ev.event_time  = "2026-03-24T10:02:00Z";
+    ev.property_op = "Changed";
+    ev.data["ObjectId"] = "7";
+    recorder.on_event(ev);
+
+    int events = static_cast<int>(bptr->events.size());
+    CHECK(events == 1,
+          "drop_unclassified: classless line crossing must still be recorded, "
+          "got " + std::to_string(events));
+  }
+}
+
 int main() {
   const std::string ubv_dir = "/tmp/test_dr_thumbs";
 
@@ -2935,6 +3031,8 @@ int main() {
            [&] { test_cell_motion_classification(ubv_dir); });
   run_test("motion_alarm_fallback",
            [&] { test_motion_alarm_fallback(ubv_dir); });
+  run_test("drop_unclassified_motion",
+           [&] { test_drop_unclassified_motion(ubv_dir); });
   run_test("cell_motion_suppresses_alarm",
            [&] { test_cell_motion_suppresses_alarm(ubv_dir); });
   run_test("ai_suppresses_cell_motion",


### PR DESCRIPTION
## Summary

Adds `--drop_unclassified_motion` (default `false`): discard generic motion events that carry no ONVIF object class and that NanoDet-M cannot classify, instead of recording them as `--default_object_type`.

**Rebased and reduced.** This PR originally carried a second change — mapping `tns1:RuleEngine/MyRuleDetector/DogCatDetect` to the `animal` smart-detect type. That is now implemented on `main` (0dbada6, along with `FaceDetect`, `Visitor`, `Package` and `LineDetector/Crossed`), so I've dropped it and rebased onto a3e0f8e. What remains is only the flag.

## Motivation

On a fleet of Reolink cameras, the Protect timeline was flooded with false **person** events. Captured live with `--event_log`/`--verbose`, the exact chain on a quiet camera (nothing in frame but wind/IR/reflections):

```
[192.168.1.23] topic=…/CellMotionDetector/Motion op=Changed
[192.168.1.23] NanoDet-M returned no detection, using smart-crop
[192.168.1.23] [alarm] triggering automation … for person on EC71DB4F6791
```

A generic motion event that NanoDet-M can't classify falls back to `--default_object_type` (`person` by default), so meaningless motion becomes a phantom person detection. This is most visible on AI cameras that already emit proper Person/Vehicle/Pet events alongside their noisy basic-motion ones.

## Behaviour

When the flag is enabled, a motion event is dropped only when **all** of these hold:

- the topic is `CellMotionDetector/Motion`, the `tt:CellMotionDetector` firmware-bug spelling, or `VideoSource/MotionAlarm`
- the detection came from the fallback path (no ONVIF object class)
- there is no per-camera `--camera_object_types` override
- NanoDet-M returned no detection
- it isn't coalescing into an existing event

Real camera AI events and `--camera_object_types` overrides are unaffected, and a coalescing merge into an existing real event is left untouched. This is the third-party analogue of the existing first-party `first_party_always_smart_detect=false` "skip on no-detection" behaviour.

Exposed in the admin UI (`runtime_config`) and documented in `FLAGS.md`.

### Why the drop is matched on topic, not `from_fallback`

The earlier revision of this PR gated on `det->from_fallback` alone. Since then, `LineDetector/Crossed` sets `from_fallback=true` when the camera reports a crossing without `ClassTypes` (detection_recorder.cpp:246) — so the old condition would have silently swallowed real line-crossing detections whenever the flag was on. The guard now names the three generic-motion topics explicitly, and a test covers it: with the flag enabled, a classless line crossing must still be recorded.

## Testing

- Added `drop_unclassified_motion` to `test_detection_recorder`, covering three cases: unclassified generic motion is dropped, a real AI event is still recorded, and a classless line crossing survives the flag.
- The pre-rebase revision of this change was built as an ARM64 `.deb` and run on a live UNVR (UniFi Protect 7.1.87) with 8 Reolink cameras — service healthy, all cameras subscribed, option visible in the admin UI, `drop_unclassified_motion=true` applied. The rebased revision has been built for ARM64 but has not yet had the same soak time on hardware.

## Notes for reviewers

- Opt-in and default `false`, so it can't change behaviour for existing deployments.
- The patch is purely additive against `main` — no lines removed.
- Verified against real Reolink topics; not tested against a non-Reolink camera (no such hardware available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
