### PR TITLE
ci: build and test on every push and PR, gate releases on green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+# Runs on every push to main and every pull request, including from forks.
+#
+# Until this existed the only thing standing between a broken commit and the
+# repo was .githooks/pre-push, which protects exactly one machine: it has to
+# be installed per clone (bazel run //:install_hooks) and it cannot run for a
+# merge made through the GitHub UI.  Contributor PRs were never built at all.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A new push to the same branch supersedes the previous run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Fast feedback: no toolchain, no Bazel, ~15 s.
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install cpplint
+        run: pip3 install --break-system-packages cpplint
+
+      - name: cpplint
+        run: python3 -m cpplint src/*.cpp src/*.hpp test/*.cpp test/*.hpp
+
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      # zstd and gperftools are always built from source; the rest of the
+      # x86 third-party tree (openssl, curl, libxml2, libpq, libmicrohttpd,
+      # libjpeg-turbo, ncnn) is fetched by Bazel, not apt.
+      - name: Init required submodules
+        run: |
+          git submodule update --init --depth 1 \
+              third_party/zstd \
+              third_party/gperftools
+
+      # Matches release-deb.yml's list minus the arm64/packaging-only bits
+      # (qemu, binutils-aarch64, reprepro, lintian, dpkg-dev, fakeroot).
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential clang cmake ninja-build perl lld nasm \
+            python3-pip curl git xz-utils \
+            autoconf automake libtool pkg-config m4
+
+      - name: Install Bazel
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/bazel \
+            https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+          sudo chmod +x /usr/local/bin/bazel
+
+      # Building openssl/curl/libxml2/libpq/ncnn from source is the bulk of
+      # the wall clock here, and none of it changes between runs.  Keyed on
+      # the files that actually determine those outputs.
+      - name: Restore Bazel disk cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bazel-disk
+          key: bazel-disk-${{ runner.os }}-${{ hashFiles('WORKSPACE', '.bazelversion', 'BUILD.bazel', 'third_party/**') }}
+          restore-keys: |
+            bazel-disk-${{ runner.os }}-
+
+      - name: Test
+        run: |
+          scripts/bz test --config=x86 \
+            --disk_cache=$HOME/.bazel-disk \
+            --test_output=errors \
+            //test:all
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bazel-test-logs
+          path: ~/.cache/bazel/x86/execroot/_main/bazel-out/*/testlogs/**
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,15 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      # zstd and gperftools are always built from source; the rest of the
-      # x86 third-party tree (openssl, curl, libxml2, libpq, libmicrohttpd,
-      # libjpeg-turbo, ncnn) is fetched by Bazel, not apt.
-      - name: Init required submodules
-        run: |
-          git submodule update --init --depth 1 \
-              third_party/zstd \
-              third_party/gperftools
+      # ALL submodules, unlike release-deb.yml which needs only zstd +
+      # gperftools.  openssl_src / curl_src / libxml2_src / libjpeg_turbo /
+      # zstd_src / gperftools_src are new_local_repository targets pointing
+      # straight at these directories, and the x86 config builds every one
+      # from source -- only the arm64 config substitutes @arm64_sysroot for
+      # curl/xml2/openssl/jpeg.  Miss one and Bazel sees an empty tree:
+      # "Configure: No such file or directory", exit 127.
+      - name: Init submodules
+        run: git submodule update --init --depth 1
 
       # Matches release-deb.yml's list minus the arm64/packaging-only bits
       # (qemu, binutils-aarch64, reprepro, lintian, dpkg-dev, fakeroot).

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -43,6 +43,9 @@ jobs:
             autoconf automake libtool pkg-config m4
           pip3 install --break-system-packages cpplint
 
+      - name: cpplint
+        run: python3 -m cpplint src/*.cpp src/*.hpp test/*.cpp test/*.hpp
+
       - name: Install Bazel
         run: |
           sudo curl -fsSL -o /usr/local/bin/bazel \
@@ -55,6 +58,14 @@ jobs:
             https://github.com/nihui/ncnn-assets/raw/refs/heads/master/models/nanodet_m.param
           curl -fL -o nanodet_m.bin \
             https://github.com/nihui/ncnn-assets/raw/refs/heads/master/models/nanodet_m.bin
+
+      # Release gate.  Nothing is built, uploaded or published to the apt
+      # repo unless the suite is green first -- a tag must not be able to
+      # ship code that fails its own tests.  Runs on x86 because that is
+      # where the tests execute; the arm64 binary below is the same sources.
+      - name: Test before releasing
+        run: |
+          scripts/bz test --config=x86 --test_output=errors //test:all
 
       - name: Compute version
         id: ver

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -27,11 +27,12 @@ jobs:
       # available as prebuilt arm64 sysroot packages.  curl / libxml2
       # / openssl / libjpeg-turbo come from @arm64_sysroot, but
       # zstd and gperftools (tcmalloc) are always built from source.
-      - name: Init required submodules
-        run: |
-          git submodule update --init --depth 1 \
-              third_party/zstd \
-              third_party/gperftools
+      # The arm64 build itself only needs zstd + gperftools (curl, libxml2,
+      # openssl and libjpeg-turbo come from @arm64_sysroot), but the x86
+      # test gate below builds all of them from source via
+      # new_local_repository, so every submodule has to be present.
+      - name: Init submodules
+        run: git submodule update --init --depth 1
 
       - name: Install system deps
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,54 @@
+name: Windows installer CI
+
+# The installer was the least-covered thing in the repo: release-windows.yml
+# only fires on a v* tag, and windows-build-test.yml is manual-only, so a PR
+# touching it reported "no checks".  That is how the SSH.NET security bump
+# (#48) arrived with nothing to validate it.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'windows-installer/**'
+      - '.github/workflows/windows-ci.yml'
+  pull_request:
+    paths:
+      - 'windows-installer/**'
+      - '.github/workflows/windows-ci.yml'
+
+concurrency:
+  group: windows-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore windows-installer/OnvifRecorderInstaller.sln
+
+      - name: Build
+        run: dotnet build windows-installer/OnvifRecorderInstaller.sln -c Release --no-restore
+
+      - name: Test
+        run: >
+          dotnet test
+          windows-installer/OnvifRecorderInstaller.Tests/OnvifRecorderInstaller.Tests.csproj
+          -c Release --no-build --verbosity normal
+
+      # Proves the single-file self-contained publish still works -- that is
+      # the shape actually shipped, and it can fail where a plain build passes
+      # (trimming, native assets, new transitive deps).
+      - name: Publish self-contained single-file exe
+        run: >
+          dotnet publish
+          windows-installer/OnvifRecorderInstaller/OnvifRecorderInstaller.csproj
+          -c Release -r win-x64 --self-contained true
+          -p:PublishSingleFile=true -o publish-out

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -47,8 +47,8 @@ configure_make(
     ],
     env = {
         # Nettle discovers GMP via CPPFLAGS/LDFLAGS (no --with-gmp-* flags).
-        "CPPFLAGS": "-I$$EXT_BUILD_DEPS$$/gmp/include",
-        "LDFLAGS": "-L$$EXT_BUILD_DEPS$$/gmp/lib",
+        "CPPFLAGS": "-I$$EXT_BUILD_DEPS/gmp/include",
+        "LDFLAGS": "-L$$EXT_BUILD_DEPS/gmp/lib",
     },
     deps = [":gmp"],
     out_static_libs = ["libnettle.a", "libhogweed.a"],
@@ -293,9 +293,9 @@ cmake(
         "CURL_BROTLI": "OFF",
         "CURL_ZSTD": "OFF",
         "USE_LIBIDN2": "OFF",
-        "OPENSSL_ROOT_DIR": "$$EXT_BUILD_DEPS$$/openssl",
-        "NGHTTP2_INCLUDE_DIR": "$$EXT_BUILD_DEPS$$/nghttp2/include",
-        "NGHTTP2_LIBRARY": "$$EXT_BUILD_DEPS$$/nghttp2/lib/libnghttp2.a",
+        "OPENSSL_ROOT_DIR": "$$EXT_BUILD_DEPS/openssl",
+        "NGHTTP2_INCLUDE_DIR": "$$EXT_BUILD_DEPS/nghttp2/include",
+        "NGHTTP2_LIBRARY": "$$EXT_BUILD_DEPS/nghttp2/lib/libnghttp2.a",
         "CMAKE_INSTALL_LIBDIR": "lib",
     },
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Nothing in CI compiled the C++ or ran the tests before this. The only protection was `.githooks/pre-push`, which guards a single machine — it must be installed per clone and cannot run for a merge made through the GitHub UI. Contributor PRs were never built: #43, #44 and the SSH.NET security bump #48 all landed with "no checks reported".

- **`ci.yml`** — cpplint plus `//test:all` on x86, on every push to main and every PR. Bazel disk cache keyed on `WORKSPACE` + `third_party/**`, since the x86 third-party tree builds from source.
- **`windows-ci.yml`** — build, `dotnet test`, and the self-contained single-file publish for `windows-installer/**`.
- **`release-deb.yml`** — now runs cpplint and `//test:all` *before* building the arm64 binary, so a tag cannot publish a release or push to the apt repo unless the suite is green.

This PR is also the first thing the new workflows run against.